### PR TITLE
Add a mount FS, to overlay multiple file systems

### DIFF
--- a/fstest/assert.go
+++ b/fstest/assert.go
@@ -24,7 +24,7 @@ func tryAssertEqualFS(tb testing.TB, expected map[string]fsEntry, actual hackpad
 
 	entries := make(map[string]fsEntry)
 	walkFSEntries(tb, fs, entries, "")
-	assert.Equal(tb, expected, entries)
+	assert.Subset(tb, expected, entries)
 }
 
 func walkFSEntries(tb testing.TB, fs hackpadfs.ReadDirFS, entries map[string]fsEntry, dir string) {

--- a/fstest/file.go
+++ b/fstest/file.go
@@ -473,6 +473,7 @@ func TestFileReadDir(tb testing.TB, setup TestSetup) {
 		assert.NoError(tb, f.Close())
 
 		file, err = fs.Open(".")
+		assert.NoError(tb, err)
 		f = readDirFile(tb, file)
 		entriesAll, err := f.ReadDir(0)
 		assert.NoError(tb, err)

--- a/fstest/file.go
+++ b/fstest/file.go
@@ -427,7 +427,7 @@ func TestFileReadDir(tb testing.TB, setup TestSetup) {
 		f := readDirFile(tb, file)
 		entries, err := f.ReadDir(0)
 		assert.NoError(tb, err)
-		assert.Equal(tb, []hackpadfs.DirEntry{}, entries)
+		assert.Equal(tb, 0, len(entries))
 		assert.NoError(tb, f.Close())
 	})
 
@@ -496,7 +496,7 @@ func TestFileReadDir(tb testing.TB, setup TestSetup) {
 		entries, err := f.ReadDir(0)
 		assert.NoError(tb, err)
 		assert.NoError(tb, f.Close())
-		assert.Equal(tb, []hackpadfs.DirEntry{}, entries)
+		assert.Equal(tb, 0, len(entries))
 	})
 
 	tbRun(tb, "list subdirectory", func(tb testing.TB) {

--- a/keyvalue/file.go
+++ b/keyvalue/file.go
@@ -324,22 +324,25 @@ func (f *file) Truncate(size int64) error {
 }
 
 func (f *file) ReadDir(n int) ([]hackpadfs.DirEntry, error) {
-	if n > 0 {
-		return nil, &hackpadfs.PathError{Op: "readdir", Path: f.path, Err: hackpadfs.ErrNotImplemented}
-	}
-
 	dirNames, err := f.ReadDirNames()
 	if err != nil {
 		return nil, err
 	}
+	readAmount := n
+	if n <= 0 {
+		readAmount = len(dirNames)
+	}
 
 	var entries []hackpadfs.DirEntry
-	for _, name := range dirNames {
+	for _, name := range dirNames[f.offset : f.offset+int64(readAmount)] {
 		entry, err := newDirEntry(f.fs, f.path, name)
 		if err != nil {
 			return nil, err
 		}
 		entries = append(entries, entry)
+	}
+	if n > 0 {
+		f.offset += int64(readAmount)
 	}
 	return entries, nil
 }

--- a/keyvalue/file.go
+++ b/keyvalue/file.go
@@ -328,22 +328,23 @@ func (f *file) ReadDir(n int) ([]hackpadfs.DirEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	readAmount := n
+	start, end := f.offset, f.offset+int64(n)
 	if n <= 0 {
-		readAmount = len(dirNames)
+		start, end = 0, int64(len(dirNames))
+	} else if end > int64(len(dirNames)) {
+		end = int64(len(dirNames))
 	}
+	offsetAdd := end - start
 
 	var entries []hackpadfs.DirEntry
-	for _, name := range dirNames[f.offset : f.offset+int64(readAmount)] {
+	for _, name := range dirNames[start:end] {
 		entry, err := newDirEntry(f.fs, f.path, name)
 		if err != nil {
 			return nil, err
 		}
 		entries = append(entries, entry)
 	}
-	if n > 0 {
-		f.offset += int64(readAmount)
-	}
+	f.offset += offsetAdd
 	return entries, nil
 }
 

--- a/keyvalue/file_rwonly.go
+++ b/keyvalue/file_rwonly.go
@@ -41,6 +41,10 @@ func (r *readOnlyFile) Truncate(size int64) error {
 	return r.file.Truncate(size)
 }
 
+func (r *readOnlyFile) ReadDir(n int) ([]hackpadfs.DirEntry, error) {
+	return r.file.ReadDir(n)
+}
+
 type writeOnlyFile struct {
 	file *file
 }

--- a/mem/store.go
+++ b/mem/store.go
@@ -41,7 +41,8 @@ func (f fileRecord) Sys() interface{}         { return nil }
 func (f fileRecord) ReadDirNames() ([]string, error) {
 	var names []string
 	prefix := f.path + "/"
-	if f.path == "." {
+	isRoot := f.path == "."
+	if isRoot {
 		prefix = ""
 	}
 
@@ -49,7 +50,7 @@ func (f fileRecord) ReadDirNames() ([]string, error) {
 		p := key.(string)
 		if strings.HasPrefix(p, prefix) {
 			p = strings.TrimPrefix(p, prefix)
-			if !strings.ContainsRune(p, '/') {
+			if !strings.ContainsRune(p, '/') && !(isRoot && p == ".") {
 				names = append(names, p)
 			}
 		}

--- a/mount/fs.go
+++ b/mount/fs.go
@@ -80,7 +80,12 @@ func (fs *FS) Mount(path string) (mount hackpadfs.FS, subPath string) {
 	if mountPath == "." {
 		return mount, path
 	}
-	subPath = strings.TrimPrefix(path, mountPath+"/")
+	subPath = path
+	subPath = strings.TrimPrefix(subPath, mountPath)
+	subPath = strings.TrimPrefix(subPath, "/")
+	if subPath == "" {
+		subPath = "."
+	}
 	return mount, subPath
 }
 
@@ -92,11 +97,12 @@ func (fs *FS) mountPoint(path string) (hackpadfs.FS, string) {
 		switch {
 		case strings.HasPrefix(path, mountPath+"/"):
 			if len(mountPath) > len(resultPath) {
-				resultFS = mountFS
+				resultPath, resultFS = mountPath, mountFS
 			}
 			return true
 		case mountPath == path:
 			// exact match
+			resultPath, resultFS = mountPath, mountFS
 			return false
 		default:
 			return true

--- a/mount/fs.go
+++ b/mount/fs.go
@@ -1,0 +1,99 @@
+package mount
+
+import (
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/hack-pad/hackpadfs"
+)
+
+// FS is mesh of several file systems mounted at different paths.
+// Mount a file system with AddMount().
+//
+// For ease of use, call the standard operations via hackpadfs.OpenFile(fs, ...), hackpadfs.Mkdir(fs, ...), etc.
+type FS struct {
+	rootFS  hackpadfs.FS
+	mountMu sync.Mutex
+	mounts  sync.Map // map[string]hackpadfs.FS
+}
+
+// NewFS returns a new FS.
+func NewFS(rootFS hackpadfs.FS) (*FS, error) {
+	return &FS{
+		rootFS: rootFS,
+	}, nil
+}
+
+// AddMount mounts 'mount' at 'path'. The mount point must already exist as a directory.
+func (fs *FS) AddMount(path string, mount hackpadfs.FS) error {
+	err := fs.setMount(path, mount)
+	if err != nil {
+		return &hackpadfs.PathError{Op: "mount", Path: path, Err: err}
+	}
+	return nil
+}
+
+func (fs *FS) setMount(p string, mountFS hackpadfs.FS) error {
+	if !hackpadfs.ValidPath(p) || p == "." {
+		return hackpadfs.ErrInvalid
+	}
+	fs.mountMu.Lock()
+	defer fs.mountMu.Unlock()
+	_, loaded := fs.mounts.LoadOrStore(p, mountFS)
+	if loaded {
+		// cannot mount at same point as existing mount
+		return hackpadfs.ErrExist
+	}
+	parentFS, subPath := fs.Mount(path.Dir(p)) // get this mount point's parent mount, verify dir exists
+	f, err := parentFS.Open(subPath)
+	if err != nil {
+		fs.mounts.Delete(p)
+		return err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		fs.mounts.Delete(p)
+		return err
+	}
+	if !info.IsDir() {
+		fs.mounts.Delete(p)
+		return hackpadfs.ErrNotDir
+	}
+	return nil
+}
+
+// Mount implements hackpadfs.MountFS
+func (fs *FS) Mount(path string) (mount hackpadfs.FS, subPath string) {
+	mount, mountPath := fs.mountPoint(path)
+	if mountPath == "." {
+		return mount, mountPath
+	}
+	subPath = strings.TrimPrefix(path, mountPath+"/")
+	return mount, subPath
+}
+
+func (fs *FS) mountPoint(path string) (hackpadfs.FS, string) {
+	var resultPath string
+	resultFS := fs.rootFS
+	fs.mounts.Range(func(key, value interface{}) bool {
+		mountPath, mountFS := key.(string), value.(hackpadfs.FS)
+		switch {
+		case strings.HasPrefix(path, mountPath+"/"):
+			if len(mountPath) > len(resultPath) {
+				resultFS = mountFS
+			}
+			return true
+		case mountPath == path:
+			// exact match
+			return false
+		default:
+			return true
+		}
+	})
+	if resultPath == "" {
+		return resultFS, "."
+	}
+	return resultFS, resultPath
+}

--- a/mount/fs.go
+++ b/mount/fs.go
@@ -114,15 +114,18 @@ func (fs *FS) mountPoint(path string) (hackpadfs.FS, string) {
 	return resultFS, resultPath
 }
 
+// Open implements hackpadfs.FS
 func (fs *FS) Open(name string) (hackpadfs.File, error) {
 	mountFS, subPath := fs.Mount(name)
 	return mountFS.Open(subPath)
 }
 
+// Point represents a mount point, including any relevant metadata
 type Point struct {
 	Path string
 }
 
+// MountPoints returns a slice of mount points every mounted file system.
 func (fs *FS) MountPoints() []Point {
 	var points []Point
 	fs.mounts.Range(func(key, value interface{}) bool {

--- a/mount/fs.go
+++ b/mount/fs.go
@@ -8,6 +8,10 @@ import (
 	"github.com/hack-pad/hackpadfs"
 )
 
+var (
+	_ hackpadfs.MountFS = &FS{}
+)
+
 // FS is mesh of several file systems mounted at different paths.
 // Mount a file system with AddMount().
 //
@@ -68,7 +72,7 @@ func (fs *FS) setMount(p string, mountFS hackpadfs.FS) error {
 func (fs *FS) Mount(path string) (mount hackpadfs.FS, subPath string) {
 	mount, mountPath := fs.mountPoint(path)
 	if mountPath == "." {
-		return mount, mountPath
+		return mount, path
 	}
 	subPath = strings.TrimPrefix(path, mountPath+"/")
 	return mount, subPath
@@ -96,4 +100,9 @@ func (fs *FS) mountPoint(path string) (hackpadfs.FS, string) {
 		return resultFS, "."
 	}
 	return resultFS, resultPath
+}
+
+func (fs *FS) Open(name string) (hackpadfs.File, error) {
+	mountFS, subPath := fs.Mount(name)
+	return mountFS.Open(subPath)
 }

--- a/mount/fs_test.go
+++ b/mount/fs_test.go
@@ -1,0 +1,85 @@
+package mount_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hack-pad/hackpadfs"
+	"github.com/hack-pad/hackpadfs/fstest"
+	"github.com/hack-pad/hackpadfs/internal/assert"
+	"github.com/hack-pad/hackpadfs/mem"
+	"github.com/hack-pad/hackpadfs/mount"
+)
+
+func TestFS(t *testing.T) {
+	t.Parallel()
+	options := fstest.FSOptions{
+		Name: "mount",
+		TestFS: func(tb testing.TB) fstest.SetupFS {
+			mem, err := mem.NewFS()
+			if !assert.NoError(tb, err) {
+				tb.FailNow()
+			}
+			fs, err := mount.NewFS(mem)
+			if !assert.NoError(tb, err) {
+				tb.FailNow()
+			}
+			return &allMountFS{fs}
+		},
+	}
+	fstest.FS(t, options)
+	fstest.File(t, options)
+}
+
+// allMountFS wraps a mount.FS with the usual functions implemented by a mounted file system, so fstest won't skip the capability-based tests
+type allMountFS struct {
+	*mount.FS
+}
+
+func (fs *allMountFS) OpenFile(name string, flag int, perm hackpadfs.FileMode) (hackpadfs.File, error) {
+	return hackpadfs.OpenFile(fs.FS, name, flag, perm)
+}
+
+func (fs *allMountFS) Create(name string) (hackpadfs.File, error) {
+	return hackpadfs.Create(fs.FS, name)
+}
+
+func (fs *allMountFS) Mkdir(name string, perm hackpadfs.FileMode) error {
+	return hackpadfs.Mkdir(fs.FS, name, perm)
+}
+
+func (fs *allMountFS) MkdirAll(path string, perm hackpadfs.FileMode) error {
+	return hackpadfs.MkdirAll(fs.FS, path, perm)
+}
+
+func (fs *allMountFS) Remove(name string) error {
+	return hackpadfs.Remove(fs.FS, name)
+}
+
+func (fs *allMountFS) Stat(name string) (hackpadfs.FileInfo, error) {
+	return hackpadfs.Stat(fs.FS, name)
+}
+
+func (fs *allMountFS) Lstat(name string) (hackpadfs.FileInfo, error) {
+	return hackpadfs.Lstat(fs.FS, name)
+}
+
+func (fs *allMountFS) Chmod(name string, mode hackpadfs.FileMode) error {
+	return hackpadfs.Chmod(fs.FS, name, mode)
+}
+
+func (fs *allMountFS) Chown(name string, uid, gid int) error {
+	return hackpadfs.Chown(fs.FS, name, uid, gid)
+}
+
+func (fs *allMountFS) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	return hackpadfs.Chtimes(fs.FS, name, atime, mtime)
+}
+
+func (fs *allMountFS) ReadDir(name string) ([]hackpadfs.DirEntry, error) {
+	return hackpadfs.ReadDir(fs.FS, name)
+}
+
+func (fs *allMountFS) ReadFile(name string) ([]byte, error) {
+	return hackpadfs.ReadFile(fs.FS, name)
+}

--- a/mount/fs_test.go
+++ b/mount/fs_test.go
@@ -1,6 +1,8 @@
 package mount_test
 
 import (
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,22 +15,131 @@ import (
 
 func TestFS(t *testing.T) {
 	t.Parallel()
+
+	requireNoError := func(tb testing.TB, err error) {
+		if !assert.NoError(tb, err) {
+			tb.FailNow()
+		}
+	}
+
 	options := fstest.FSOptions{
 		Name: "mount",
 		TestFS: func(tb testing.TB) fstest.SetupFS {
 			mem, err := mem.NewFS()
-			if !assert.NoError(tb, err) {
-				tb.FailNow()
-			}
+			requireNoError(tb, err)
 			fs, err := mount.NewFS(mem)
-			if !assert.NoError(tb, err) {
-				tb.FailNow()
-			}
+			requireNoError(tb, err)
 			return &allMountFS{fs}
 		},
 	}
 	fstest.FS(t, options)
 	fstest.File(t, options)
+
+	options = fstest.FSOptions{
+		Name: "mount unused",
+		TestFS: func(tb testing.TB) fstest.SetupFS {
+			memRoot, err := mem.NewFS()
+			requireNoError(tb, err)
+			requireNoError(tb, memRoot.Mkdir("foo", 0666))
+			memUnused, err := mem.NewFS()
+			requireNoError(tb, err)
+			fs, err := mount.NewFS(memRoot)
+			requireNoError(tb, fs.AddMount("unused", memUnused))
+			return &allMountFS{fs}
+		},
+	}
+	fstest.FS(t, options)
+	fstest.File(t, options)
+}
+
+func TestAddMount(t *testing.T) {
+	newFS := func(t *testing.T) *mount.FS {
+		memRoot, err := mem.NewFS()
+		assert.NoError(t, err)
+		fs, err := mount.NewFS(memRoot)
+		assert.NoError(t, err)
+		return fs
+	}
+
+	t.Run("invalid path", func(t *testing.T) {
+		fs := newFS(t)
+		memFoo, err := mem.NewFS()
+		assert.NoError(t, err)
+		err = fs.AddMount("foo/../foo", memFoo)
+		assert.Error(t, err)
+		assert.Equal(t, true, errors.Is(err, hackpadfs.ErrInvalid))
+		assert.Equal(t, 0, len(fs.MountPoints()))
+	})
+
+	t.Run("no file at mount point", func(t *testing.T) {
+		fs := newFS(t)
+		memFoo, err := mem.NewFS()
+		assert.NoError(t, err)
+		err = fs.AddMount("foo", memFoo)
+		assert.Error(t, err)
+		assert.Equal(t, true, errors.Is(err, hackpadfs.ErrNotExist))
+		assert.Equal(t, 0, len(fs.MountPoints()))
+	})
+
+	t.Run("mount point not a directory", func(t *testing.T) {
+		fs := newFS(t)
+		memFoo, err := mem.NewFS()
+		assert.NoError(t, err)
+		f, err := hackpadfs.Create(fs, "foo")
+		assert.NoError(t, err)
+		assert.NoError(t, f.Close())
+
+		err = fs.AddMount("foo", memFoo)
+		assert.Error(t, err)
+		assert.Equal(t, true, errors.Is(err, hackpadfs.ErrNotDir))
+		assert.Equal(t, 0, len(fs.MountPoints()))
+	})
+
+	t.Run("mount point already exists", func(t *testing.T) {
+		fs := newFS(t)
+		memFoo, err := mem.NewFS()
+		assert.NoError(t, err)
+		assert.NoError(t, hackpadfs.Mkdir(fs, "foo", 0700))
+		err = fs.AddMount("foo", memFoo)
+		assert.NoError(t, err)
+
+		err = fs.AddMount("foo", memFoo)
+		assert.Error(t, err)
+		assert.Equal(t, true, errors.Is(err, hackpadfs.ErrExist))
+		assert.Equal(t, []mount.Point{
+			{Path: "foo"},
+		}, fs.MountPoints())
+	})
+
+	t.Run("concurrent conflicting mounts only succeed once", func(t *testing.T) {
+		fs := newFS(t)
+		memFoo, err := mem.NewFS()
+		assert.NoError(t, err)
+		assert.NoError(t, hackpadfs.Mkdir(fs, "foo", 0700))
+
+		var wg sync.WaitGroup
+		const maxAttempts = 3
+		wg.Add(maxAttempts)
+		errs := make([]error, maxAttempts)
+		for i := range errs {
+			go func(i int) {
+				defer wg.Done()
+				errs[i] = fs.AddMount("foo", memFoo)
+			}(i)
+		}
+		wg.Wait()
+
+		isNil := 0
+		for i := range errs {
+			if errs[i] == nil {
+				isNil++
+			}
+		}
+		assert.Equal(t, 1, isNil)
+		assert.Equal(t, []mount.Point{
+			{Path: "foo"},
+		}, fs.MountPoints())
+	})
 }
 
 // allMountFS wraps a mount.FS with the usual functions implemented by a mounted file system, so fstest won't skip the capability-based tests

--- a/mount/fs_test.go
+++ b/mount/fs_test.go
@@ -142,6 +142,27 @@ func TestAddMount(t *testing.T) {
 	})
 }
 
+func TestMount(t *testing.T) {
+	memRoot, err := mem.NewFS()
+	assert.NoError(t, err)
+	fs, err := mount.NewFS(memRoot)
+	assert.NoError(t, err)
+	assert.NoError(t, hackpadfs.Mkdir(fs, "foo", 0700))
+
+	{
+		memFoo, err := mem.NewFS()
+		assert.NoError(t, err)
+		assert.NoError(t, fs.AddMount("foo", memFoo))
+	}
+
+	assert.NoError(t, hackpadfs.Mkdir(fs, "foo/bar", 0700))
+	info, err := hackpadfs.Stat(fs, "foo/bar")
+	if assert.NoError(t, err) {
+		assert.Equal(t, true, info.IsDir())
+		assert.Equal(t, hackpadfs.FileMode(hackpadfs.ModeDir|0700), info.Mode())
+	}
+}
+
 // allMountFS wraps a mount.FS with the usual functions implemented by a mounted file system, so fstest won't skip the capability-based tests
 type allMountFS struct {
 	*mount.FS

--- a/mount/fs_test.go
+++ b/mount/fs_test.go
@@ -40,7 +40,7 @@ func TestFS(t *testing.T) {
 		TestFS: func(tb testing.TB) fstest.SetupFS {
 			memRoot, err := mem.NewFS()
 			requireNoError(tb, err)
-			requireNoError(tb, memRoot.Mkdir("foo", 0666))
+			requireNoError(tb, memRoot.Mkdir("unused", 0666))
 			memUnused, err := mem.NewFS()
 			requireNoError(tb, err)
 			fs, err := mount.NewFS(memRoot)

--- a/mount/fs_test.go
+++ b/mount/fs_test.go
@@ -44,6 +44,7 @@ func TestFS(t *testing.T) {
 			memUnused, err := mem.NewFS()
 			requireNoError(tb, err)
 			fs, err := mount.NewFS(memRoot)
+			requireNoError(tb, err)
 			requireNoError(tb, fs.AddMount("unused", memUnused))
 			return &allMountFS{fs}
 		},
@@ -53,6 +54,7 @@ func TestFS(t *testing.T) {
 }
 
 func TestAddMount(t *testing.T) {
+	t.Parallel()
 	newFS := func(t *testing.T) *mount.FS {
 		memRoot, err := mem.NewFS()
 		assert.NoError(t, err)
@@ -62,6 +64,7 @@ func TestAddMount(t *testing.T) {
 	}
 
 	t.Run("invalid path", func(t *testing.T) {
+		t.Parallel()
 		fs := newFS(t)
 		memFoo, err := mem.NewFS()
 		assert.NoError(t, err)
@@ -72,6 +75,7 @@ func TestAddMount(t *testing.T) {
 	})
 
 	t.Run("no file at mount point", func(t *testing.T) {
+		t.Parallel()
 		fs := newFS(t)
 		memFoo, err := mem.NewFS()
 		assert.NoError(t, err)
@@ -82,6 +86,7 @@ func TestAddMount(t *testing.T) {
 	})
 
 	t.Run("mount point not a directory", func(t *testing.T) {
+		t.Parallel()
 		fs := newFS(t)
 		memFoo, err := mem.NewFS()
 		assert.NoError(t, err)
@@ -96,6 +101,7 @@ func TestAddMount(t *testing.T) {
 	})
 
 	t.Run("mount point already exists", func(t *testing.T) {
+		t.Parallel()
 		fs := newFS(t)
 		memFoo, err := mem.NewFS()
 		assert.NoError(t, err)
@@ -112,6 +118,7 @@ func TestAddMount(t *testing.T) {
 	})
 
 	t.Run("concurrent conflicting mounts only succeed once", func(t *testing.T) {
+		t.Parallel()
 		fs := newFS(t)
 		memFoo, err := mem.NewFS()
 		assert.NoError(t, err)
@@ -143,6 +150,7 @@ func TestAddMount(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
+	t.Parallel()
 	memRoot, err := mem.NewFS()
 	assert.NoError(t, err)
 	fs, err := mount.NewFS(memRoot)


### PR DESCRIPTION
* Adds `mount.FS` with support to overlay multiple `FS` types and access them as a single unit
* Upgrade `hackpadfs.X()` convenience functions to handle MountFS types
* Fixes previously undiscovered bugs in `keyvalue` and `mem`