### PR TITLE
Add new cache FS, various bug fixes

### DIFF
--- a/cache/dir.go
+++ b/cache/dir.go
@@ -1,0 +1,42 @@
+package cache
+
+import (
+	"io"
+
+	"github.com/hack-pad/hackpadfs"
+)
+
+type dir struct {
+	fs     *ReadOnlyFS
+	name   string
+	offset int
+}
+
+func (d *dir) Read(p []byte) (n int, err error) {
+	return 0, &hackpadfs.PathError{Op: "read", Path: d.name, Err: hackpadfs.ErrIsDir}
+}
+
+func (d *dir) Close() error {
+	return nil
+}
+
+func (d *dir) Stat() (hackpadfs.FileInfo, error) {
+	return hackpadfs.Stat(d.fs, d.name)
+}
+
+func (d *dir) ReadDir(n int) ([]hackpadfs.DirEntry, error) {
+	entries, err := hackpadfs.ReadDir(d.fs.sourceFS, d.name)
+	if err != nil {
+		return nil, err
+	}
+	if n > 0 && d.offset == len(entries) {
+		return nil, io.EOF
+	}
+	if n <= 0 || d.offset+n > len(entries) {
+		d.offset = n
+	} else {
+		entries = entries[d.offset : d.offset+n]
+		d.offset += n
+	}
+	return entries, nil
+}

--- a/cache/fs.go
+++ b/cache/fs.go
@@ -24,12 +24,12 @@ type ReadOnlyFS struct {
 }
 
 type ReadOnlyOptions struct {
-	RetainData func(name string) bool
+	RetainData func(name string, info hackpadfs.FileInfo) bool
 }
 
 func NewReadOnlyFS(source hackpadfs.FS, cache writableFS, options ReadOnlyOptions) (*ReadOnlyFS, error) {
 	if options.RetainData == nil {
-		options.RetainData = func(string) bool { return true }
+		options.RetainData = func(string, hackpadfs.FileInfo) bool { return true }
 	}
 	return &ReadOnlyFS{
 		sourceFS: source,
@@ -63,7 +63,7 @@ func (fs *ReadOnlyFS) Open(name string) (hackpadfs.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !fs.options.RetainData(name) {
+	if !fs.options.RetainData(name, info) {
 		return f, nil
 	}
 

--- a/cache/fs.go
+++ b/cache/fs.go
@@ -1,0 +1,151 @@
+package cache
+
+import (
+	"errors"
+	"io"
+	"path"
+	"sync"
+
+	"github.com/hack-pad/hackpadfs"
+)
+
+type writableFS interface {
+	hackpadfs.OpenFileFS
+	hackpadfs.MkdirFS
+}
+
+type ReadOnlyFS struct {
+	sourceFS  hackpadfs.FS
+	cacheFS   writableFS
+	cacheInfo sync.Map
+
+	mu      sync.Mutex
+	options ReadOnlyOptions
+}
+
+type ReadOnlyOptions struct {
+	RetainData func(name string) bool
+}
+
+func NewReadOnlyFS(source hackpadfs.FS, cache writableFS, options ReadOnlyOptions) (*ReadOnlyFS, error) {
+	if options.RetainData == nil {
+		options.RetainData = func(string) bool { return true }
+	}
+	return &ReadOnlyFS{
+		sourceFS: source,
+		cacheFS:  cache,
+		options:  options,
+	}, nil
+}
+
+func (fs *ReadOnlyFS) Open(name string) (hackpadfs.File, error) {
+	// if source file is a dir or encounters an error, return early
+	info, err := fs.Stat(name)
+	switch {
+	case err == nil && info.IsDir():
+		return &dir{fs: fs, name: name}, nil
+	case err != nil:
+		return nil, err
+	}
+
+	{
+		// if file is in cache, return it. continue otherwise
+		f, err := fs.cacheFS.Open(name)
+		if err == nil {
+			return f, nil
+		}
+		if !errors.Is(err, hackpadfs.ErrNotExist) {
+			return nil, err
+		}
+	}
+
+	f, err := fs.sourceFS.Open(name) // guaranteed not to be a directory
+	if err != nil {
+		return nil, err
+	}
+	if !fs.options.RetainData(name) {
+		return f, nil
+	}
+
+	err = fs.copyFile(name, f, info)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	if _, err := hackpadfs.SeekFile(f, 0, io.SeekStart); err != nil {
+		// attempt to seek to first byte. if unsuccessful, re-open file from the cache
+		f.Close()
+		f, err = fs.cacheFS.Open(name)
+	}
+	return f, err
+}
+
+func (fs *ReadOnlyFS) copyFile(name string, f hackpadfs.File, info hackpadfs.FileInfo) error {
+	parentName := path.Dir(name)
+	parentInfo, err := fs.Stat(parentName)
+	if err != nil {
+		return err
+	}
+	if err := fs.mkdir(parentName, parentInfo); err != nil {
+		return &hackpadfs.PathError{Op: "open", Path: parentName, Err: err}
+	}
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	destFile, err := fs.cacheFS.OpenFile(name, hackpadfs.FlagWriteOnly|hackpadfs.FlagCreate|hackpadfs.FlagTruncate, info.Mode())
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	destFileWriter, ok := destFile.(io.Writer)
+	if !ok {
+		return &hackpadfs.PathError{Op: "open", Path: name, Err: hackpadfs.ErrPermission}
+	}
+	buf := make([]byte, 512)
+	_, err = io.CopyBuffer(destFileWriter, f, buf)
+	return err
+}
+
+func (fs *ReadOnlyFS) mkdir(name string, info hackpadfs.FileInfo) error {
+	if name == "." {
+		return nil
+	}
+	if !info.IsDir() {
+		return hackpadfs.ErrNotDir
+	}
+	err := hackpadfs.Mkdir(fs.cacheFS, name, info.Mode())
+	switch {
+	case errors.Is(err, hackpadfs.ErrNotExist):
+		parentName := path.Dir(name)
+		parentInfo, err := fs.Stat(parentName)
+		if err != nil {
+			return err
+		}
+		err = fs.mkdir(parentName, parentInfo)
+		if err != nil {
+			return err
+		}
+		return hackpadfs.Mkdir(fs.cacheFS, name, info.Mode())
+	case errors.Is(err, hackpadfs.ErrExist):
+		return nil
+	default:
+		return err
+	}
+}
+
+func (fs *ReadOnlyFS) Stat(name string) (hackpadfs.FileInfo, error) {
+	if infoV, loaded := fs.cacheInfo.Load(name); loaded {
+		return infoV.(hackpadfs.FileInfo), nil
+	}
+	f, err := fs.sourceFS.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	fs.cacheInfo.Store(name, info)
+	return info, nil
+}

--- a/cache/fs.go
+++ b/cache/fs.go
@@ -21,7 +21,7 @@ type ReadOnlyFS struct {
 	cacheFS   writableFS
 	cacheInfo sync.Map
 
-	pathlock pathlock.Lock
+	pathlock pathlock.Mutex
 	options  ReadOnlyOptions
 }
 

--- a/cache/fs_test.go
+++ b/cache/fs_test.go
@@ -1,0 +1,37 @@
+package cache_test
+
+import (
+	"testing"
+
+	"github.com/hack-pad/hackpadfs"
+	"github.com/hack-pad/hackpadfs/cache"
+	"github.com/hack-pad/hackpadfs/fstest"
+	"github.com/hack-pad/hackpadfs/internal/assert"
+	"github.com/hack-pad/hackpadfs/mem"
+)
+
+func TestFS(t *testing.T) {
+	t.Parallel()
+	options := fstest.FSOptions{
+		Name: "cache",
+		Setup: fstest.TestSetupFunc(func(tb testing.TB) (fstest.SetupFS, func() hackpadfs.FS) {
+			sourceFS, err := mem.NewFS()
+			if !assert.NoError(tb, err) {
+				tb.FailNow()
+			}
+			cacheFS, err := mem.NewFS()
+			if !assert.NoError(tb, err) {
+				tb.FailNow()
+			}
+			fs, err := cache.NewReadOnlyFS(sourceFS, cacheFS, cache.ReadOnlyOptions{})
+			if !assert.NoError(tb, err) {
+				tb.FailNow()
+			}
+			return sourceFS, func() hackpadfs.FS {
+				return fs
+			}
+		}),
+	}
+	fstest.FS(t, options)
+	fstest.File(t, options)
+}

--- a/fstest/file.go
+++ b/fstest/file.go
@@ -329,8 +329,11 @@ func testFileWrite(tb testing.TB, setup TestSetup, writer func(hackpadfs.File, [
 			assert.NoError(tb, f.Close())
 		}
 
-		fs := commit()
-		f, err = hackpadfs.OpenFile(fs, "foo", hackpadfs.FlagReadWrite, 0)
+		fs, ok := commit().(hackpadfs.OpenFileFS)
+		if !ok {
+			tb.Skip("FS is not an OpenFileFS")
+		}
+		f, err = fs.OpenFile("foo", hackpadfs.FlagReadWrite, 0)
 		assert.NoError(tb, err)
 		n, err := writer(f, []byte(fileContents))
 		assert.Equal(tb, len(fileContents), n)
@@ -353,8 +356,11 @@ func testFileWrite(tb testing.TB, setup TestSetup, writer func(hackpadfs.File, [
 			assert.NoError(tb, f.Close())
 		}
 
-		fs := commit()
-		f, err = hackpadfs.OpenFile(fs, "foo", hackpadfs.FlagReadWrite|hackpadfs.FlagTruncate, 0)
+		fs, ok := commit().(hackpadfs.OpenFileFS)
+		if !ok {
+			tb.Skip("FS is not an OpenFileFS")
+		}
+		f, err = fs.OpenFile("foo", hackpadfs.FlagReadWrite|hackpadfs.FlagTruncate, 0)
 		assert.NoError(tb, err)
 		n, err := writer(f, []byte(fileContents))
 		assert.Equal(tb, len(fileContents), n)
@@ -384,8 +390,11 @@ func TestFileWriteAt(tb testing.TB, setup TestSetup) {
 			assert.NoError(tb, file.Close())
 		}
 
-		fs := commit()
-		file, err = hackpadfs.OpenFile(fs, "foo", hackpadfs.FlagReadWrite, 0)
+		fs, ok := commit().(hackpadfs.OpenFileFS)
+		if !ok {
+			tb.Skip("FS is not an OpenFileFS")
+		}
+		file, err = fs.OpenFile("foo", hackpadfs.FlagReadWrite, 0)
 		assert.NoError(tb, err)
 		f := writeAtFile(tb, file)
 		n, err := f.WriteAt([]byte("hello"), -1)
@@ -408,8 +417,11 @@ func TestFileWriteAt(tb testing.TB, setup TestSetup) {
 			assert.NoError(tb, file.Close())
 		}
 
-		fs := commit()
-		file, err = hackpadfs.OpenFile(fs, "foo", hackpadfs.FlagReadWrite, 0)
+		fs, ok := commit().(hackpadfs.OpenFileFS)
+		if !ok {
+			tb.Skip("FS is not an OpenFileFS")
+		}
+		file, err = fs.OpenFile("foo", hackpadfs.FlagReadWrite, 0)
 		assert.NoError(tb, err)
 		f := writeAtFile(tb, file)
 		const fileContents = "hello world"
@@ -433,8 +445,11 @@ func TestFileWriteAt(tb testing.TB, setup TestSetup) {
 			assert.NoError(tb, file.Close())
 		}
 
-		fs := commit()
-		file, err = hackpadfs.OpenFile(fs, "foo", hackpadfs.FlagReadWrite, 0)
+		fs, ok := commit().(hackpadfs.OpenFileFS)
+		if !ok {
+			tb.Skip("FS is not an OpenFileFS")
+		}
+		file, err = fs.OpenFile("foo", hackpadfs.FlagReadWrite, 0)
 		assert.NoError(tb, err)
 		f := writeAtFile(tb, file)
 		const fileContents = "hello world"
@@ -462,8 +477,11 @@ func TestFileWriteAt(tb testing.TB, setup TestSetup) {
 			assert.NoError(tb, file.Close())
 		}
 
-		fs := commit()
-		file, err = hackpadfs.OpenFile(fs, "foo", hackpadfs.FlagReadWrite, 0)
+		fs, ok := commit().(hackpadfs.OpenFileFS)
+		if !ok {
+			tb.Skip("FS is not an OpenFileFS")
+		}
+		file, err = fs.OpenFile("foo", hackpadfs.FlagReadWrite, 0)
 		assert.NoError(tb, err)
 		f := writeAtFile(tb, file)
 		const fileContents = "hello world"
@@ -688,7 +706,10 @@ func TestFileTruncate(tb testing.TB, setup TestSetup) {
 				assert.NoError(tb, err)
 			}
 
-			fs := commit()
+			fs, ok := commit().(hackpadfs.OpenFileFS)
+			if !ok {
+				tb.Skip("FS is not an OpenFileFS")
+			}
 			file, err = hackpadfs.OpenFile(fs, "foo", hackpadfs.FlagReadWrite, 0)
 			assert.NoError(tb, err)
 			f, ok := file.(hackpadfs.TruncaterFile)

--- a/fstest/fs.go
+++ b/fstest/fs.go
@@ -120,6 +120,9 @@ func TestCreate(tb testing.TB, setup TestSetup) {
 }
 
 func testCreate(tb testing.TB, setup TestSetup, createFn func(hackpadfs.FS, string) (hackpadfs.File, error)) {
+	_, commit := setup.FS(tb)
+	_, _ = createFn(commit(), "foo") // trigger tb.Skip() for incompatible FS's
+
 	tbRun(tb, "new file", func(tb testing.TB) {
 		_, commit := setup.FS(tb)
 		fs := commit()
@@ -386,6 +389,9 @@ func TestOpen(tb testing.TB, setup TestSetup) {
 }
 
 func testOpen(tb testing.TB, setup TestSetup, openFn func(hackpadfs.FS, string) (hackpadfs.File, error)) {
+	_, commit := setup.FS(tb)
+	_, _ = openFn(commit(), "foo") // trigger tb.Skip() for incompatible FS's
+
 	tbRun(tb, "invalid path", func(tb testing.TB) {
 		_, commit := setup.FS(tb)
 		fs := commit()

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/hack-pad/hackpadfs
 
 go 1.16
 
-require github.com/hack-pad/go-indexeddb v0.0.0-20210627055059-75ac2a19af43
+require github.com/hack-pad/go-indexeddb v0.0.0-20210725225828-552e7c407090

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/hack-pad/go-indexeddb v0.0.0-20210627055059-75ac2a19af43 h1:L1SDHWiwFsHGy67AVE4JzQUaU1CgPVhF21YVlYzxQLQ=
 github.com/hack-pad/go-indexeddb v0.0.0-20210627055059-75ac2a19af43/go.mod h1:NH8CaojufPNcKYDhy5JkjfyBXE/72oJPeiywlabN/lM=
+github.com/hack-pad/go-indexeddb v0.0.0-20210725225828-552e7c407090 h1:CVuJ/4qGfYmIcYDiPUriwbEuimA4O34zf/EsrSKDpS4=
+github.com/hack-pad/go-indexeddb v0.0.0-20210725225828-552e7c407090/go.mod h1:NH8CaojufPNcKYDhy5JkjfyBXE/72oJPeiywlabN/lM=

--- a/indexeddb/idbblob/blob.go
+++ b/indexeddb/idbblob/blob.go
@@ -154,25 +154,25 @@ func (b *Blob) Slice(start, end int64) (blob.Blob, error) {
 }
 
 // Set implements blob.SetBlob
-func (b *Blob) Set(dest blob.Blob, srcStart int64) (n int, err error) {
-	if srcStart < 0 {
+func (b *Blob) Set(src blob.Blob, destStart int64) (n int, err error) {
+	if destStart < 0 {
 		return 0, errors.New("negative offset")
 	}
-	if srcStart >= int64(b.Len()) && srcStart == 0 && dest.Len() > 0 {
-		return 0, fmt.Errorf("Offset out of bounds: %d", srcStart)
+	if destStart >= int64(b.Len()) && destStart == 0 && src.Len() > 0 {
+		return 0, fmt.Errorf("Offset out of bounds: %d", destStart)
 	}
 
 	err = catchErr(func() error {
-		b.JSValue().Call("set", FromBlob(dest), srcStart)
+		b.JSValue().Call("set", FromBlob(src), destStart)
 		return nil
 	})
 	if err != nil {
 		return 0, err
 	}
-	n = dest.Len()
+	n = src.Len()
 
 	if buf := b.currentBytes(); buf != nil {
-		_, err := buf.Set(dest, srcStart)
+		_, err := buf.Set(src, destStart)
 		if err != nil {
 			panic(err)
 		}

--- a/indexeddb/transaction.go
+++ b/indexeddb/transaction.go
@@ -174,7 +174,7 @@ func (t *transaction) Commit(ctx context.Context) ([]keyvalue.OpResult, error) {
 		fn()
 	}
 	t.resultsMu.Lock()
-	var results []keyvalue.OpResult
+	results := make([]keyvalue.OpResult, 0, len(t.results))
 	for _, result := range t.results {
 		results = append(results, result)
 	}

--- a/internal/pathlock/lock.go
+++ b/internal/pathlock/lock.go
@@ -1,0 +1,24 @@
+package pathlock
+
+import "sync"
+
+type Lock struct {
+	pathLocks sync.Map
+}
+
+func New() *Lock {
+	return &Lock{}
+}
+
+func (l *Lock) Lock(path string) {
+	var newMu sync.Mutex
+	muInterface, _ := l.pathLocks.LoadOrStore(path, &newMu)
+	mu := muInterface.(*sync.Mutex)
+	mu.Lock()
+}
+
+func (l *Lock) Unlock(path string) {
+	muInterface, _ := l.pathLocks.Load(path)
+	mu := muInterface.(*sync.Mutex)
+	mu.Unlock()
+}

--- a/internal/pathlock/lock.go
+++ b/internal/pathlock/lock.go
@@ -2,22 +2,26 @@ package pathlock
 
 import "sync"
 
-type Lock struct {
+// Mutex is a path-based locker. Lock a given path for exclusive access to that path.
+type Mutex struct {
 	pathLocks sync.Map
 }
 
-func New() *Lock {
-	return &Lock{}
+// New returns a new Mutex
+func New() *Mutex {
+	return &Mutex{}
 }
 
-func (l *Lock) Lock(path string) {
+// Lock blocks access to 'path' until Unlock is called
+func (l *Mutex) Lock(path string) {
 	var newMu sync.Mutex
 	muInterface, _ := l.pathLocks.LoadOrStore(path, &newMu)
 	mu := muInterface.(*sync.Mutex)
 	mu.Lock()
 }
 
-func (l *Lock) Unlock(path string) {
+// Unlock unblocks access to 'path'
+func (l *Mutex) Unlock(path string) {
 	muInterface, _ := l.pathLocks.Load(path)
 	mu := muInterface.(*sync.Mutex)
 	mu.Unlock()

--- a/keyvalue/blob/blob.go
+++ b/keyvalue/blob/blob.go
@@ -22,11 +22,11 @@ type SliceBlob interface {
 	Slice(start, end int64) (Blob, error)
 }
 
-// SetBlob is a Blob that can copy 'dest' into itself starting at the given offset into this Blob.
-// Use View() on 'dest' to control the maximum that is copied into this Blob.
+// SetBlob is a Blob that can copy 'src' into itself starting at the given offset into this Blob.
+// Use View() on 'src' to control the maximum that is copied into this Blob.
 type SetBlob interface {
 	Blob
-	Set(dest Blob, offset int64) (n int, err error)
+	Set(src Blob, offset int64) (n int, err error)
 }
 
 // GrowBlob is a Blob that can increase it's size by allocating offset bytes at the end.

--- a/keyvalue/blob/bytes.go
+++ b/keyvalue/blob/bytes.go
@@ -74,15 +74,15 @@ func (b *Bytes) Slice(start, end int64) (Blob, error) {
 }
 
 // Set implements Blob.
-func (b *Bytes) Set(dest Blob, srcStart int64) (n int, err error) {
-	if srcStart < 0 {
+func (b *Bytes) Set(src Blob, destStart int64) (n int, err error) {
+	if destStart < 0 {
 		return 0, errors.New("negative offset")
 	}
-	if srcStart >= int64(b.Len()) && srcStart == 0 && dest.Len() > 0 {
-		return 0, fmt.Errorf("Offset out of bounds: %d", srcStart)
+	if destStart >= int64(b.Len()) && destStart == 0 && src.Len() > 0 {
+		return 0, fmt.Errorf("Offset out of bounds: %d", destStart)
 	}
 	b.mu.Lock()
-	n = copy(b.bytes[srcStart:], dest.Bytes())
+	n = copy(b.bytes[destStart:], src.Bytes())
 	b.mu.Unlock()
 	return n, nil
 }

--- a/keyvalue/blob/bytes.go
+++ b/keyvalue/blob/bytes.go
@@ -64,6 +64,8 @@ func (b *Bytes) View(start, end int64) (Blob, error) {
 	if end < 0 || end > int64(b.Len()) {
 		return nil, fmt.Errorf("End index out of bounds: %d", end)
 	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	newB := NewBytes(b.bytes[start:end])
 	newB.mu = b.mu
 	return newB, nil

--- a/mem/store.go
+++ b/mem/store.go
@@ -31,7 +31,7 @@ type fileRecord struct {
 }
 
 func (f fileRecord) Data() (blob.Blob, error) {
-	return blob.NewBytes(f.data.Bytes()).Slice(0, int64(f.data.Len()))
+	return f.data, nil
 }
 
 func (f fileRecord) Size() int64              { return int64(f.data.Len()) }


### PR DESCRIPTION
* Add new cache FS
* indexeddb FS:
    - Bump `idb` to latest to pick up context leak fixes
    - Preallocate results slice for transaction.Commit()
* keyvalue FS:
    - Fix data race in blob.Bytes when reslicing for a View
    - Fix blob.Bytes data races when sharing byte slices
    - Fix SetBlob arg naming to match behavior
* fstest:
    - Trigger tb.Skip() before sub-tests run to avoid panic(nil) complaints
    - Skip Writer tests for read-only FSs
* mem: Return original blob when retrieving file data
