### PR TITLE
Add tar.ReaderFS: A streaming tar FS for memory and time-constrained programs

### DIFF
--- a/internal/fserrors/errors.go
+++ b/internal/fserrors/errors.go
@@ -1,0 +1,25 @@
+package fserrors
+
+type messageError struct {
+	err     error
+	message string
+}
+
+// WithMessage annotates 'err' with the prefix 'message'. Returns nil if 'err' is nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &messageError{
+		err:     err,
+		message: message,
+	}
+}
+
+func (m *messageError) Error() string {
+	return m.message + ": " + m.err.Error()
+}
+
+func (m *messageError) Unwrap() error {
+	return m.err
+}

--- a/internal/fserrors/errors_test.go
+++ b/internal/fserrors/errors_test.go
@@ -1,0 +1,22 @@
+package fserrors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hack-pad/hackpadfs/internal/assert"
+)
+
+func TestWithMessage(t *testing.T) {
+	t.Parallel()
+	someError := fmt.Errorf("some error")
+	err := WithMessage(someError, "some message")
+	if assert.Error(t, err) {
+		assert.Equal(t, "some message: some error", err.Error())
+	}
+	assert.Equal(t, true, errors.Is(err, someError))
+
+	err = WithMessage(nil, "some message")
+	assert.NoError(t, err)
+}

--- a/tar/bufferpool.go
+++ b/tar/bufferpool.go
@@ -1,0 +1,64 @@
+package tar
+
+import (
+	"sync/atomic"
+)
+
+// bufferPool maintains a collection of byte buffers with a maximum size.
+// Used to control upper-bound memory usage. It's safe for concurrent use.
+type bufferPool struct {
+	count   int64
+	size    uint64
+	buffers chan *buffer
+}
+
+type buffer struct {
+	Data []byte
+	pool *bufferPool
+}
+
+func newBufferPool(bufferSize, maxBuffers uint64) *bufferPool {
+	if maxBuffers == 0 {
+		maxBuffers = 1
+	}
+	p := &bufferPool{
+		size:    bufferSize,
+		buffers: make(chan *buffer, maxBuffers),
+	}
+	p.addBuffer() // start with 1 buffer, ready to go
+	return p
+}
+
+func (p *bufferPool) addBuffer() {
+	for {
+		count := atomic.LoadInt64(&p.count)
+		if int(count) == cap(p.buffers) {
+			return // already at max buffers, no-op
+		}
+		if atomic.CompareAndSwapInt64(&p.count, count, count+1) {
+			break // successfully provisioned slot for new buffer
+		}
+	}
+	buf := &buffer{
+		Data: make([]byte, p.size),
+		pool: p,
+	}
+	p.buffers <- buf
+}
+
+// Wait acquires and returns a buffer. Be sure to call buffer.Done() to return it to the pool.
+func (p *bufferPool) Wait() *buffer {
+	select {
+	case buf := <-p.buffers:
+		return buf
+	default:
+		p.addBuffer()
+		// may not always get the new buffer, but looping could allocate more buffers far too quickly
+		return <-p.buffers
+	}
+}
+
+// Done returns this buffer to the pool
+func (b *buffer) Done() {
+	b.pool.buffers <- b
+}

--- a/tar/fs.go
+++ b/tar/fs.go
@@ -1,0 +1,313 @@
+package tar
+
+import (
+	"archive/tar"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/hack-pad/hackpadfs"
+	"github.com/hack-pad/hackpadfs/internal/fserrors"
+	"github.com/hack-pad/hackpadfs/mem"
+)
+
+// ReaderFS is a tar-based file system, reading files and metadata from a tar archive's io.Reader.
+//
+// A ReaderFS is ready to use immediately after returning from the non-blocking constructor NewReaderFS().
+// This means the files are concurrently unpacked and accessible.
+// If a file has not yet been unpacked, that file's operation will block until it is unpacked.
+// If a directory's dir entries are accessed, that operation will block until the entire archive has been unpacked. (Tar ordering can't be guaranteed.)
+type ReaderFS struct {
+	unarchiveFS baseFS
+	ps          *pubsub
+	// callerCtx is passed in through the constructor, controlling when we should stop reading
+	callerCtx context.Context
+	// callerCancel can cancel the callerCtx early, like when reading completes
+	callerCancel context.CancelFunc
+	// readerCtx represents the "canceled" state of the reader, Done() returns this done channel
+	readerCtx context.Context
+	// readerDone is called once reading has completed - either from cancelling callertCtx, encountering an error, or completing successfully
+	readerDone   context.CancelFunc
+	unarchiveErr atomic.Value
+}
+
+var _ hackpadfs.FS = &ReaderFS{}
+
+// ReaderFSOptions provides configuration options for a new ReaderFS.
+type ReaderFSOptions struct {
+	// UnarchiveFS is the destination FS to unarchive the reader into. Defaults to mem.FS.
+	UnarchiveFS baseFS
+}
+
+type baseFS interface {
+	hackpadfs.OpenFileFS
+	hackpadfs.ChmodFS
+	hackpadfs.MkdirFS
+}
+
+// NewReaderFS returns a new ReaderFS from the given tar archive reader and options.
+// Attempts to close the reader once the tar has completely unpacked.
+//
+// If using a gzipped tar, be sure to pass the tar reader and not the original gzip reader.
+func NewReaderFS(ctx context.Context, r io.Reader, options ReaderFSOptions) (_ *ReaderFS, retErr error) {
+	defer func() { retErr = fserrors.WithMessage(retErr, "tar") }()
+
+	if options.UnarchiveFS == nil {
+		var err error
+		options.UnarchiveFS, err = mem.NewFS()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if dirEntries, err := hackpadfs.ReadDir(options.UnarchiveFS, "."); err != nil || len(dirEntries) != 0 {
+		var names []string
+		for _, dirEntry := range dirEntries {
+			names = append(names, dirEntry.Name())
+		}
+		return nil, fmt.Errorf("root '.' of options.UnarchiveFS must be an empty directory, got: %T %v %s", options.UnarchiveFS, err, names)
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	readerCtx, readerDone := context.WithCancel(context.Background())
+	fs := &ReaderFS{
+		unarchiveFS:  options.UnarchiveFS,
+		ps:           newPubsub(ctx),
+		callerCtx:    ctx,
+		callerCancel: cancel,
+		readerCtx:    readerCtx,
+		readerDone:   readerDone,
+	}
+	go fs.read(r)
+	return fs, nil
+}
+
+func (fs *ReaderFS) read(r io.Reader) {
+	err := fs.readErr(r)
+	if err != nil {
+		fs.unarchiveErr.Store(err)
+	}
+	fs.callerCancel()
+	fs.readerDone()
+
+	if closer, ok := r.(io.Closer); ok {
+		_ = closer.Close()
+	}
+}
+
+func (fs *ReaderFS) readErr(r io.Reader) error {
+	archive := tar.NewReader(r)
+	const (
+		mebibyte       = 1 << 20
+		kibibyte       = 1 << 10
+		maxMemory      = 20 * mebibyte
+		bigBufMemory   = 4 * mebibyte
+		smallBufMemory = 150 * kibibyte
+
+		// at least a couple big and small buffers, then a large quantity of small ones make up the remainder
+		bigBufCount   = 2
+		smallBufCount = (maxMemory - bigBufCount*bigBufMemory) / smallBufMemory
+	)
+	// set up some buffer pools to reduce maximum memory usage. small buffers are for every file's first read, big buffers for secondary reads.
+	smallPool := newBufferPool(smallBufMemory, smallBufCount)
+	bigPool := newBufferPool(bigBufMemory, bigBufCount)
+
+	mkdirCache := make(map[string]bool) // avoid calling Mkdir more than once on the same path
+	cachedMkdirAll := func(path string, perm hackpadfs.FileMode) error {
+		if _, ok := mkdirCache[path]; ok {
+			return nil
+		}
+		err := hackpadfs.MkdirAll(fs.unarchiveFS, path, perm)
+		if err == nil {
+			mkdirCache[path] = true
+		}
+		return err
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 1)
+	for {
+		select {
+		case err := <-errs:
+			return err
+		default:
+		}
+		header, err := archive.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fserrors.WithMessage(err, "next tar file")
+		}
+		err = fs.readProcessFile(header, archive, &wg, errs, cachedMkdirAll, smallPool, bigPool)
+		if err != nil {
+			return err
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case err := <-errs:
+		return err
+	case <-done:
+		return nil
+	}
+}
+
+// resolvePath converts a tar based path to a rooted FS path
+func resolvePath(p string) string {
+	p = path.Clean(p)
+	p = strings.TrimPrefix(p, "/")
+	if p == "" {
+		p = "."
+	}
+	return p
+}
+
+func (fs *ReaderFS) readProcessFile(
+	header *tar.Header, r io.Reader,
+	wg *sync.WaitGroup, errs chan error,
+	mkdirAll func(string, hackpadfs.FileMode) error,
+	smallPool, bigPool *bufferPool,
+) error {
+	select {
+	case <-fs.callerCtx.Done():
+		return fs.callerCtx.Err()
+	default:
+	}
+
+	originalName := header.Name
+	p := resolvePath(originalName)
+	info := header.FileInfo()
+
+	dir := path.Dir(p)
+	err := mkdirAll(dir, 0700)
+	if err != nil {
+		return fserrors.WithMessage(err, "prepping base dir")
+	}
+
+	if info.IsDir() {
+		// assume dir does not exist yet, then chmod if it does exist
+		wg.Add(1)
+		go func() { // continue prepping dir in the background
+			defer wg.Done()
+			err := fs.unarchiveFS.Mkdir(p, info.Mode())
+			if err != nil {
+				if !errors.Is(err, hackpadfs.ErrExist) {
+					errs <- fserrors.WithMessage(err, "copying dir")
+					return
+				}
+				err = fs.unarchiveFS.Chmod(p, info.Mode())
+				if err != nil {
+					errs <- fserrors.WithMessage(err, "copying dir")
+					return
+				}
+			}
+		}()
+		return nil
+	}
+
+	reader := fullReader{r} // fullReader: call f.Write as few times as possible, since large files can be expensive to write in many batches (Hackpad JS Blobs)
+	// read once. if we reached EOF, then write it to fs asynchronously
+	smallBuf := smallPool.Wait()
+	n, err := reader.Read(smallBuf.Data)
+	switch err {
+	case io.EOF:
+		wg.Add(1)
+		go func() { // continue prepping small file in the background
+			err := fs.writeFile(p, info, smallBuf, n, nil, nil)
+			smallBuf.Done()
+			if err != nil {
+				errs <- err
+			}
+			wg.Done()
+		}()
+		return nil
+	case nil:
+		// prep large file in the foreground to finish reading the file (going to next file in tar invalidates the file reader)
+		bigBuf := bigPool.Wait()
+		err := fs.writeFile(p, info, smallBuf, n, reader, bigBuf)
+		bigBuf.Done()
+		smallBuf.Done()
+		return err
+	default:
+		return err
+	}
+}
+
+func (fs *ReaderFS) writeFile(path string, info hackpadfs.FileInfo, initialBuf *buffer, n int, r io.Reader, copyBuf *buffer) (returnedErr error) {
+	f, err := fs.unarchiveFS.OpenFile(path, hackpadfs.FlagWriteOnly|hackpadfs.FlagCreate|hackpadfs.FlagTruncate, info.Mode())
+	if err != nil {
+		return fserrors.WithMessage(err, "opening destination file")
+	}
+	defer func() {
+		_ = f.Close()
+		if returnedErr == nil {
+			fs.ps.Emit(path) // only emit for non-dirs, dirs will wait until the total tar read completes to ensure correctness
+		}
+	}()
+
+	fWriter, ok := f.(io.Writer)
+	if !ok {
+		return hackpadfs.ErrNotImplemented
+	}
+
+	_, err = fWriter.Write(initialBuf.Data[:n])
+	if err != nil {
+		return fserrors.WithMessage(err, "write: copying file")
+	}
+
+	if r == nil {
+		// a nil reader signals we already did a read of N bytes and hit EOF,
+		// so the above copy is sufficient, return now
+		return nil
+	}
+
+	_, err = io.CopyBuffer(fWriter, r, copyBuf.Data)
+	return fserrors.WithMessage(err, "copybuf: copying file")
+}
+
+type fullReader struct {
+	io.Reader
+}
+
+func (f fullReader) Read(p []byte) (n int, err error) {
+	n, err = io.ReadFull(f.Reader, p)
+	if err == io.ErrUnexpectedEOF {
+		err = io.EOF
+	}
+	return
+}
+
+// Open implements hackpadfs.FS
+func (fs *ReaderFS) Open(name string) (hackpadfs.File, error) {
+	if !hackpadfs.ValidPath(name) {
+		return nil, &hackpadfs.PathError{Op: "open", Path: name, Err: hackpadfs.ErrInvalid}
+	}
+	fs.ps.Wait(name)
+	if unarchiveErr := fs.UnarchiveErr(); unarchiveErr != nil {
+		return nil, &hackpadfs.PathError{Op: "open", Path: name, Err: unarchiveErr}
+	}
+	return fs.unarchiveFS.Open(name)
+}
+
+// Done returns a channel that's closed when either the tar has been completely unpacked or the unarchive fails.
+// The channel may close some time after the initial context is closed.
+func (fs *ReaderFS) Done() <-chan struct{} {
+	return fs.readerCtx.Done()
+}
+
+// UnarchiveErr returns the error, if any, that occurred during unpacking. Behavior is undefined if Done() has not completed.
+func (fs *ReaderFS) UnarchiveErr() error {
+	err, _ := fs.unarchiveErr.Load().(error)
+	return err
+}

--- a/tar/fs_test.go
+++ b/tar/fs_test.go
@@ -1,0 +1,161 @@
+package tar
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/hack-pad/hackpadfs"
+	"github.com/hack-pad/hackpadfs/fstest"
+	"github.com/hack-pad/hackpadfs/internal/assert"
+	"github.com/hack-pad/hackpadfs/internal/fserrors"
+	"github.com/hack-pad/hackpadfs/mem"
+)
+
+func TestFS(t *testing.T) {
+	t.Parallel()
+	options := fstest.FSOptions{
+		Name: "tar",
+		Setup: fstest.TestSetupFunc(func(tb testing.TB) (fstest.SetupFS, func() hackpadfs.FS) {
+			setupFS, err := mem.NewFS()
+			if !assert.NoError(tb, err) {
+				tb.FailNow()
+			}
+
+			return setupFS, func() hackpadfs.FS {
+				return newTarFromFS(tb, setupFS)
+			}
+		}),
+	}
+	fstest.FS(t, options)
+	fstest.File(t, options)
+}
+
+func newTarFromFS(tb testing.TB, src hackpadfs.FS) *ReaderFS {
+	r, err := buildTarFromFS(tb, src)
+	if !assert.NoError(tb, err) {
+		tb.FailNow()
+	}
+
+	fs, err := NewReaderFS(context.Background(), r, ReaderFSOptions{})
+	if !assert.NoError(tb, err) {
+		tb.FailNow()
+	}
+	return fs
+}
+
+func buildTarFromFS(tb testing.TB, src hackpadfs.FS) (io.Reader, error) {
+	var buf bytes.Buffer
+	archive := tar.NewWriter(&buf)
+	defer func() { assert.NoError(tb, archive.Close()) }()
+
+	err := hackpadfs.WalkDir(src, ".", copyTarWalk(src, archive))
+	return &buf, fserrors.WithMessage(err, "Failed building tar from FS walk")
+}
+
+func copyTarWalk(src hackpadfs.FS, archive *tar.Writer) hackpadfs.WalkDirFunc {
+	return func(path string, dir hackpadfs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := dir.Info()
+		if err != nil {
+			return err
+		}
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		header.Name = path
+		if info.IsDir() {
+			header.Name += "/"
+		}
+		err = archive.WriteHeader(header)
+		if err != nil {
+			return err
+		}
+		fileBytes, err := hackpadfs.ReadFile(src, path)
+		if err != nil {
+			return err
+		}
+		_, err = archive.Write(fileBytes)
+		return err
+	}
+}
+
+// TestNewTarFromFS is a sanity check on the constructor we use in fstest. Just make sure it behaves normally for simple cases.
+func TestNewTarFromFS(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		description string
+		do          func(t *testing.T, fs hackpadfs.FS)
+	}{
+		{
+			description: "empty",
+			do:          func(t *testing.T, fs hackpadfs.FS) {},
+		},
+		{
+			description: "one file",
+			do: func(t *testing.T, fs hackpadfs.FS) {
+				_, err := hackpadfs.Create(fs, "foo")
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+			},
+		},
+		{
+			description: "one dir",
+			do: func(t *testing.T, fs hackpadfs.FS) {
+				err := hackpadfs.Mkdir(fs, "foo", 0700)
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+			},
+		},
+		{
+			description: "dir with one nested file",
+			do: func(t *testing.T, fs hackpadfs.FS) {
+				err := hackpadfs.Mkdir(fs, "foo", 0700)
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+				_, err = hackpadfs.Create(fs, "foo/bar")
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+			},
+		},
+	} {
+		tc := tc // enable parallel sub-tests
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+			memFS, err := mem.NewFS()
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			tc.do(t, memFS)
+			timer := time.NewTimer(50 * time.Millisecond)
+			done := make(chan struct{})
+
+			go func() {
+				tarFS := newTarFromFS(t, memFS)
+				assert.NoError(t, err)
+				assert.NotEqual(t, nil, tarFS)
+				close(done)
+			}()
+
+			select {
+			case <-done:
+				timer.Stop()
+			case <-timer.C:
+				buf := make([]byte, 4096)
+				n := runtime.Stack(buf, true)
+				t.Fatalf("Took too long:\n%s", string(buf[:n]))
+			}
+		})
+	}
+}

--- a/tar/pubsub.go
+++ b/tar/pubsub.go
@@ -1,0 +1,61 @@
+package tar
+
+import (
+	"context"
+	"sync"
+)
+
+type pubsub struct {
+	mu          sync.RWMutex
+	subscribers map[string][]context.CancelFunc
+	visited     map[string]bool
+	ctx         context.Context
+}
+
+// newPubsub creates a new pubsub that unblocks all calls to Wait when ctx is canceled
+func newPubsub(ctx context.Context) *pubsub {
+	return &pubsub{
+		ctx:         ctx,
+		subscribers: make(map[string][]context.CancelFunc),
+		visited:     make(map[string]bool),
+	}
+}
+
+func (ps *pubsub) Emit(key string) {
+	ps.mu.RLock()
+	visited := ps.visited[key]
+	ps.mu.RUnlock()
+	if visited {
+		return
+	}
+	ps.mu.Lock()
+	ps.visited[key] = true
+	funcs := ps.subscribers[key]
+	ps.subscribers[key] = nil
+	ps.mu.Unlock()
+	for _, cancel := range funcs {
+		cancel()
+	}
+}
+
+func (ps *pubsub) Wait(key string) {
+	select {
+	case <-ps.ctx.Done():
+		return
+	default:
+	}
+
+	ps.mu.Lock()
+	if ps.visited[key] {
+		ps.mu.Unlock()
+		return
+	}
+	ctx, cancel := context.WithCancel(ps.ctx)
+	ps.subscribers[key] = append(ps.subscribers[key], cancel)
+	ps.mu.Unlock()
+
+	select {
+	case <-ps.ctx.Done():
+	case <-ctx.Done():
+	}
+}

--- a/tar/pubsub_test.go
+++ b/tar/pubsub_test.go
@@ -1,0 +1,33 @@
+package tar
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPubSub(t *testing.T) {
+	t.Parallel()
+	t.Run("emit first", func(t *testing.T) {
+		t.Parallel()
+		ps := newPubsub(context.Background())
+		ps.Emit("hi")
+		ps.Wait("hi")
+	})
+
+	t.Run("wait first", func(t *testing.T) {
+		t.Parallel()
+		ps := newPubsub(context.Background())
+		wait := make(chan struct{})
+		completed := make(chan struct{})
+		go func() {
+			close(wait)
+			ps.Wait("hi")
+			close(completed)
+		}()
+		<-wait
+		for _, key := range []string{"a", "b", "c", "hi"} {
+			ps.Emit(key)
+		}
+		<-completed
+	})
+}


### PR DESCRIPTION

Ported from github.com/hack-pad/hackpad/internal/tarfs

Also add fserrors pkg to prepend error cause information
