### PR TITLE
os: Add Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         platform: 
         - ubuntu-latest
         - macos-latest
-        - windows-2019
+        - windows-latest
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         platform: 
         - ubuntu-latest
         - macos-latest
-        - windows-latest
+        - windows-2019
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,13 @@ jobs:
       run: make lint
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: 
+        - ubuntu-latest
+        - macos-latest
+        - windows-latest
+    runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,11 @@ test-deps:
 test: test-deps
 	go test .  # Run library-level checks first, for more helpful build tag failure messages.
 	go test -race -coverprofile=cover.out ./...
-	if [[ "$$CI" != true || GOOS == linux ]]; then \
-		GOOS=js GOARCH=wasm go test -cover ./...; \
+	if [[ "$$CI" != true || $$(uname -s) == Linux ]]; then \
+		GOOS=js GOARCH=wasm go test -cover ./... && \
+		cd examples && go test -race ./...; \
 	fi
-	cd examples && go test -race ./...
-	@if [[ "$$CI" == true && GOOS == linux ]]; then \
+	@if [[ "$$CI" == true && $$(uname -s) == Linux ]]; then \
 		set -ex; \
 		goveralls -coverprofile=cover.out -service=github; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,11 @@ test-deps:
 test: test-deps
 	go test .  # Run library-level checks first, for more helpful build tag failure messages.
 	go test -race -coverprofile=cover.out ./...
-	GOOS=js GOARCH=wasm go test -cover ./...
+	if [[ "$$CI" != true || GOOS == linux ]]; then \
+		GOOS=js GOARCH=wasm go test -cover ./...; \
+	fi
 	cd examples && go test -race ./...
-	@if [[ "$$CI" == true ]]; then \
+	@if [[ "$$CI" == true && GOOS == linux ]]; then \
 		set -ex; \
 		goveralls -coverprofile=cover.out -service=github; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ test: test-deps
 	go test .  # Run library-level checks first, for more helpful build tag failure messages.
 	go test -race -coverprofile=cover.out ./...
 	if [[ "$$CI" != true || $$(uname -s) == Linux ]]; then \
-		GOOS=js GOARCH=wasm go test -cover ./... && \
+		set -ex; \
+		GOOS=js GOARCH=wasm go test -cover ./...; \
 		cd examples && go test -race ./...; \
 	fi
 	@if [[ "$$CI" == true && $$(uname -s) == Linux ]]; then \

--- a/fstest/assert.go
+++ b/fstest/assert.go
@@ -23,7 +23,7 @@ func (o FSOptions) tryAssertEqualFS(tb testing.TB, expected map[string]fsEntry, 
 	}
 
 	for path, entry := range expected {
-		entry.Mode = entry.Mode & o.Constraints.FileModeMask
+		entry.Mode &= o.Constraints.FileModeMask
 		expected[path] = entry
 	}
 
@@ -50,7 +50,7 @@ func (o FSOptions) walkFSEntries(tb testing.TB, fs hackpadfs.ReadDirFS, entries 
 				size = info.Size()
 			}
 		}
-		mode = mode & o.Constraints.FileModeMask
+		mode &= o.Constraints.FileModeMask
 
 		name := entry.Name()
 		assert.Equal(tb, true, hackpadfs.ValidPath(name))
@@ -71,18 +71,18 @@ func (o FSOptions) walkFSEntries(tb testing.TB, fs hackpadfs.ReadDirFS, entries 
 
 func (o FSOptions) assertEqualQuickInfo(tb testing.TB, a, b quickInfo) bool {
 	tb.Helper()
-	a.Mode = a.Mode & o.Constraints.FileModeMask
-	b.Mode = b.Mode & o.Constraints.FileModeMask
+	a.Mode &= o.Constraints.FileModeMask
+	b.Mode &= o.Constraints.FileModeMask
 	return assert.Equal(tb, a, b)
 }
 
 func (o FSOptions) assertEqualQuickInfos(tb testing.TB, a, b []quickInfo) bool {
 	tb.Helper()
 	for i := range a {
-		a[i].Mode = a[i].Mode & o.Constraints.FileModeMask
+		a[i].Mode &= o.Constraints.FileModeMask
 	}
 	for i := range b {
-		b[i].Mode = b[i].Mode & o.Constraints.FileModeMask
+		b[i].Mode &= o.Constraints.FileModeMask
 	}
 	return assert.Equal(tb, a, b)
 }
@@ -90,10 +90,10 @@ func (o FSOptions) assertEqualQuickInfos(tb testing.TB, a, b []quickInfo) bool {
 func (o FSOptions) assertSubsetQuickInfos(tb testing.TB, a, b []quickInfo) bool {
 	tb.Helper()
 	for i := range a {
-		a[i].Mode = a[i].Mode & o.Constraints.FileModeMask
+		a[i].Mode &= o.Constraints.FileModeMask
 	}
 	for i := range b {
-		b[i].Mode = b[i].Mode & o.Constraints.FileModeMask
+		b[i].Mode &= o.Constraints.FileModeMask
 	}
 	return assert.Subset(tb, a, b)
 }

--- a/fstest/assert.go
+++ b/fstest/assert.go
@@ -86,3 +86,14 @@ func (o FSOptions) assertEqualQuickInfos(tb testing.TB, a, b []quickInfo) bool {
 	}
 	return assert.Equal(tb, a, b)
 }
+
+func (o FSOptions) assertSubsetQuickInfos(tb testing.TB, a, b []quickInfo) bool {
+	tb.Helper()
+	for i := range a {
+		a[i].Mode = a[i].Mode & o.Constraints.FileModeMask
+	}
+	for i := range b {
+		b[i].Mode = b[i].Mode & o.Constraints.FileModeMask
+	}
+	return assert.Subset(tb, a, b)
+}

--- a/fstest/file.go
+++ b/fstest/file.go
@@ -167,7 +167,7 @@ func TestFileReadAt(tb testing.TB, o FSOptions) {
 					assert.Equal(tb, "readat", err.Op)
 					assert.Equal(tb, "foo", err.Path)
 				}
-				assert.Equal(tb, true, errors.Is(err, tc.expectErr))
+				assert.ErrorIs(tb, tc.expectErr, err)
 				return
 			}
 			assert.NoError(tb, err)
@@ -206,7 +206,7 @@ func TestFileSeek(tb testing.TB, o FSOptions) {
 			err := err.(*hackpadfs.PathError)
 			assert.Equal(tb, "seek", err.Op)
 			assert.Equal(tb, "foo", err.Path)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrInvalid))
+			assert.ErrorIs(tb, hackpadfs.ErrInvalid, err)
 		}
 		assert.NoError(tb, f.Close())
 	})
@@ -229,7 +229,7 @@ func TestFileSeek(tb testing.TB, o FSOptions) {
 			err := err.(*hackpadfs.PathError)
 			assert.Equal(tb, "seek", err.Op)
 			assert.Equal(tb, "foo", err.Path)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrInvalid))
+			assert.ErrorIs(tb, hackpadfs.ErrInvalid, err)
 		}
 		assert.NoError(tb, f.Close())
 	})
@@ -711,6 +711,7 @@ func TestFileTruncate(tb testing.TB, o FSOptions) {
 			if assert.NoError(tb, err) {
 				_, err = hackpadfs.WriteFile(file, []byte(fileContents))
 				assert.NoError(tb, err)
+				assert.NoError(tb, file.Close())
 			}
 
 			fs, ok := commit().(hackpadfs.OpenFileFS)
@@ -731,7 +732,7 @@ func TestFileTruncate(tb testing.TB, o FSOptions) {
 					err := err.(*hackpadfs.PathError)
 					assert.Equal(tb, "truncate", err.Op)
 					assert.Equal(tb, "foo", err.Path)
-					assert.Equal(tb, tc.expectErrKind, err.Err)
+					assert.ErrorIs(tb, tc.expectErrKind, err.Err)
 				}
 				o.tryAssertEqualFS(tb, map[string]fsEntry{
 					"foo": {Mode: 0666, Size: int64(len(fileContents))},

--- a/fstest/file.go
+++ b/fstest/file.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hack-pad/hackpadfs/internal/assert"
 )
 
-func TestFileClose(tb testing.TB, setup TestSetup) {
-	setupFS, commit := setup.FS(tb)
+func TestFileClose(tb testing.TB, o FSOptions) {
+	setupFS, commit := o.Setup.FS(tb)
 	f, err := hackpadfs.Create(setupFS, "foo")
 	if assert.NoError(tb, err) {
 		assert.NoError(tb, f.Close())
@@ -27,10 +27,10 @@ func TestFileClose(tb testing.TB, setup TestSetup) {
 	}
 }
 
-func TestFileRead(tb testing.TB, setup TestSetup) {
+func TestFileRead(tb testing.TB, o FSOptions) {
 	const fileContents = "hello world"
 	tbRun(tb, "read empty", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			assert.NoError(tb, f.Close())
@@ -49,7 +49,7 @@ func TestFileRead(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "read a few bytes at a time", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		const firstBufLen = 2
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -87,9 +87,9 @@ func TestFileRead(tb testing.TB, setup TestSetup) {
 	})
 }
 
-func TestFileReadAt(tb testing.TB, setup TestSetup) {
+func TestFileReadAt(tb testing.TB, o FSOptions) {
 	const fileContents = "hello world"
-	setupFS, commit := setup.FS(tb)
+	setupFS, commit := o.Setup.FS(tb)
 	f, err := hackpadfs.Create(setupFS, "foo")
 	if assert.NoError(tb, err) {
 		_, err = hackpadfs.WriteFile(f, []byte(fileContents))
@@ -177,7 +177,7 @@ func TestFileReadAt(tb testing.TB, setup TestSetup) {
 	}
 }
 
-func TestFileSeek(tb testing.TB, setup TestSetup) {
+func TestFileSeek(tb testing.TB, o FSOptions) {
 	const fileContents = "hello world"
 
 	seekFile := func(tb testing.TB, file hackpadfs.File) hackpadfs.SeekerFile {
@@ -189,7 +189,7 @@ func TestFileSeek(tb testing.TB, setup TestSetup) {
 	}
 
 	tbRun(tb, "seek unknown start", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			_, err = hackpadfs.WriteFile(file, []byte(fileContents))
@@ -212,7 +212,7 @@ func TestFileSeek(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "seek negative offset", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			_, err = hackpadfs.WriteFile(file, []byte(fileContents))
@@ -235,7 +235,7 @@ func TestFileSeek(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "seek start", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			_, err = hackpadfs.WriteFile(file, []byte(fileContents))
@@ -259,7 +259,7 @@ func TestFileSeek(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "seek current", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			_, err = hackpadfs.WriteFile(file, []byte(fileContents))
@@ -286,7 +286,7 @@ func TestFileSeek(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "seek end", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			_, err = hackpadfs.WriteFile(file, []byte(fileContents))
@@ -310,8 +310,8 @@ func TestFileSeek(tb testing.TB, setup TestSetup) {
 	})
 }
 
-func TestFileWrite(tb testing.TB, setup TestSetup) {
-	testFileWrite(tb, setup, func(file hackpadfs.File, b []byte) (int, error) {
+func TestFileWrite(tb testing.TB, o FSOptions) {
+	testFileWrite(tb, o, func(file hackpadfs.File, b []byte) (int, error) {
 		if file, ok := file.(hackpadfs.ReadWriterFile); ok {
 			return file.Write(b)
 		}
@@ -320,10 +320,10 @@ func TestFileWrite(tb testing.TB, setup TestSetup) {
 	})
 }
 
-func testFileWrite(tb testing.TB, setup TestSetup, writer func(hackpadfs.File, []byte) (int, error)) {
+func testFileWrite(tb testing.TB, o FSOptions, writer func(hackpadfs.File, []byte) (int, error)) {
 	tbRun(tb, "write-read", func(tb testing.TB) {
 		const fileContents = "hello world"
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			assert.NoError(tb, f.Close())
@@ -348,7 +348,7 @@ func testFileWrite(tb testing.TB, setup TestSetup, writer func(hackpadfs.File, [
 
 	tbRun(tb, "write-truncate-write-read", func(tb testing.TB) {
 		const fileContents = "hello world"
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			_, err := writer(f, []byte(fileContents))
@@ -374,7 +374,7 @@ func testFileWrite(tb testing.TB, setup TestSetup, writer func(hackpadfs.File, [
 	})
 }
 
-func TestFileWriteAt(tb testing.TB, setup TestSetup) {
+func TestFileWriteAt(tb testing.TB, o FSOptions) {
 	writeAtFile := func(tb testing.TB, file hackpadfs.File) hackpadfs.WriterAtFile {
 		if file, ok := file.(hackpadfs.WriterAtFile); ok {
 			return file
@@ -384,7 +384,7 @@ func TestFileWriteAt(tb testing.TB, setup TestSetup) {
 	}
 
 	tbRun(tb, "negative offset", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			assert.NoError(tb, file.Close())
@@ -411,7 +411,7 @@ func TestFileWriteAt(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "no offset", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			assert.NoError(tb, file.Close())
@@ -439,7 +439,7 @@ func TestFileWriteAt(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "offset inside file", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			assert.NoError(tb, file.Close())
@@ -471,7 +471,7 @@ func TestFileWriteAt(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "offset outside file", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			assert.NoError(tb, file.Close())
@@ -500,7 +500,7 @@ func TestFileWriteAt(tb testing.TB, setup TestSetup) {
 	})
 }
 
-func TestFileReadDir(tb testing.TB, setup TestSetup) {
+func TestFileReadDir(tb testing.TB, o FSOptions) {
 	readDirFile := func(tb testing.TB, file hackpadfs.File) hackpadfs.DirReaderFile {
 		if file, ok := file.(hackpadfs.DirReaderFile); ok {
 			return file
@@ -510,7 +510,7 @@ func TestFileReadDir(tb testing.TB, setup TestSetup) {
 	}
 
 	tbRun(tb, "list initial root", func(tb testing.TB) {
-		_, commit := setup.FS(tb)
+		_, commit := o.Setup.FS(tb)
 		fs := commit()
 		file, err := fs.Open(".")
 		assert.NoError(tb, err)
@@ -521,7 +521,7 @@ func TestFileReadDir(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "list root", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			assert.NoError(tb, file.Close())
@@ -545,7 +545,7 @@ func TestFileReadDir(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "readdir batches", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			assert.NoError(tb, file.Close())
@@ -581,7 +581,7 @@ func TestFileReadDir(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "readdir high N", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "bar", 0700))
 
 		fs := commit()
@@ -594,7 +594,7 @@ func TestFileReadDir(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "list empty subdirectory", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
 
 		fs := commit()
@@ -608,7 +608,7 @@ func TestFileReadDir(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "list subdirectory", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
 		file, err := hackpadfs.Create(setupFS, "foo/bar")
 		if assert.NoError(tb, err) {
@@ -630,7 +630,7 @@ func TestFileReadDir(tb testing.TB, setup TestSetup) {
 		sort.SliceStable(entries, func(a, b int) bool {
 			return entries[a].Name() < entries[b].Name()
 		})
-		assert.Equal(tb, []quickInfo{
+		o.assertEqualQuickInfos(tb, []quickInfo{
 			{Name: "bar", Mode: 0666},
 			{Name: "baz", Mode: 0666},
 			{Name: "boo", Mode: hackpadfs.ModeDir | 0700, IsDir: true},
@@ -638,8 +638,8 @@ func TestFileReadDir(tb testing.TB, setup TestSetup) {
 	})
 }
 
-func TestFileStat(tb testing.TB, setup TestSetup) {
-	testStat(tb, setup, func(tb testing.TB, fs hackpadfs.FS, path string) (hackpadfs.FileInfo, error) {
+func TestFileStat(tb testing.TB, o FSOptions) {
+	testStat(tb, o, func(tb testing.TB, fs hackpadfs.FS, path string) (hackpadfs.FileInfo, error) {
 		tb.Helper()
 		f, err := fs.Open(path)
 		if err != nil {
@@ -652,8 +652,8 @@ func TestFileStat(tb testing.TB, setup TestSetup) {
 	})
 }
 
-func TestFileSync(tb testing.TB, setup TestSetup) {
-	setupFS, commit := setup.FS(tb)
+func TestFileSync(tb testing.TB, o FSOptions) {
+	setupFS, commit := o.Setup.FS(tb)
 	const fileContents = "hello world"
 	file, err := hackpadfs.Create(setupFS, "foo")
 	if assert.NoError(tb, err) {
@@ -663,17 +663,24 @@ func TestFileSync(tb testing.TB, setup TestSetup) {
 	}
 
 	fs := commit()
-	file, err = fs.Open("foo")
+	if openFileFS, ok := fs.(hackpadfs.OpenFileFS); ok {
+		// some FSs require write access to perform a sync (Windows), so try to add that access
+		file, err = openFileFS.OpenFile("foo", hackpadfs.FlagWriteOnly, 0)
+	} else {
+		file, err = fs.Open("foo")
+	}
 	assert.NoError(tb, err)
 	f, ok := file.(hackpadfs.SyncerFile)
 	if !ok {
 		tb.Skip("File is not a SyncerFile")
 	}
+	_, err = hackpadfs.WriteFile(f, []byte("hello"))
+	assert.NoError(tb, err)
 	assert.NoError(tb, f.Sync())
 	assert.NoError(tb, f.Close())
 }
 
-func TestFileTruncate(tb testing.TB, setup TestSetup) {
+func TestFileTruncate(tb testing.TB, o FSOptions) {
 	const fileContents = "hello world"
 	for _, tc := range []struct {
 		description   string
@@ -699,7 +706,7 @@ func TestFileTruncate(tb testing.TB, setup TestSetup) {
 		},
 	} {
 		tbRun(tb, tc.description, func(tb testing.TB) {
-			setupFS, commit := setup.FS(tb)
+			setupFS, commit := o.Setup.FS(tb)
 			file, err := hackpadfs.Create(setupFS, "foo")
 			if assert.NoError(tb, err) {
 				_, err = hackpadfs.WriteFile(file, []byte(fileContents))
@@ -726,12 +733,12 @@ func TestFileTruncate(tb testing.TB, setup TestSetup) {
 					assert.Equal(tb, "foo", err.Path)
 					assert.Equal(tb, tc.expectErrKind, err.Err)
 				}
-				tryAssertEqualFS(tb, map[string]fsEntry{
+				o.tryAssertEqualFS(tb, map[string]fsEntry{
 					"foo": {Mode: 0666, Size: int64(len(fileContents))},
 				}, fs)
 			} else {
 				assert.NoError(tb, err)
-				tryAssertEqualFS(tb, map[string]fsEntry{
+				o.tryAssertEqualFS(tb, map[string]fsEntry{
 					"foo": {Mode: 0666, Size: tc.size},
 				}, fs)
 			}

--- a/fstest/file.go
+++ b/fstest/file.go
@@ -189,6 +189,9 @@ func TestFileSeek(tb testing.TB, o FSOptions) {
 	}
 
 	tbRun(tb, "seek unknown start", func(tb testing.TB) {
+		if o.Constraints.InvalidSeekWhenceUndefined {
+			tb.Skip("Invalid 'whence' value in Seek() is left as undefined behavior")
+		}
 		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -344,6 +347,7 @@ func testFileWrite(tb testing.TB, o FSOptions, writer func(hackpadfs.File, []byt
 		buf := make([]byte, len(fileContents))
 		_, _ = f.Read(buf)
 		assert.Equal(tb, fileContents, string(buf))
+		assert.NoError(tb, f.Close())
 	})
 
 	tbRun(tb, "write-truncate-write-read", func(tb testing.TB) {
@@ -371,6 +375,7 @@ func testFileWrite(tb testing.TB, o FSOptions, writer func(hackpadfs.File, []byt
 		buf := make([]byte, len(fileContents))
 		_, _ = f.Read(buf)
 		assert.Equal(tb, fileContents, string(buf))
+		assert.NoError(tb, f.Close())
 	})
 }
 

--- a/fstest/file.go
+++ b/fstest/file.go
@@ -592,6 +592,7 @@ func TestFileReadDir(tb testing.TB, o FSOptions) {
 		f := readDirFile(tb, file)
 		entries, err := f.ReadDir(100000000)
 		assert.NoError(tb, err)
+		assert.NoError(tb, file.Close())
 		o.assertSubsetQuickInfos(tb,
 			[]quickInfo{{Name: "bar", Mode: hackpadfs.ModeDir | 0700, IsDir: true}},
 			asQuickDirInfos(tb, entries),

--- a/fstest/file.go
+++ b/fstest/file.go
@@ -29,7 +29,7 @@ func TestFileClose(tb testing.TB, o FSOptions) {
 
 func TestFileRead(tb testing.TB, o FSOptions) {
 	const fileContents = "hello world"
-	tbRun(tb, "read empty", func(tb testing.TB) {
+	o.tbRun(tb, "read empty", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -48,7 +48,7 @@ func TestFileRead(tb testing.TB, o FSOptions) {
 		assert.NoError(tb, f.Close())
 	})
 
-	tbRun(tb, "read a few bytes at a time", func(tb testing.TB) {
+	o.tbRun(tb, "read a few bytes at a time", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		const firstBufLen = 2
 		f, err := hackpadfs.Create(setupFS, "foo")
@@ -143,7 +143,7 @@ func TestFileReadAt(tb testing.TB, o FSOptions) {
 			expectErr:   io.EOF,
 		},
 	} {
-		tbRun(tb, tc.description, func(tb testing.TB) {
+		o.tbRun(tb, tc.description, func(tb testing.TB) {
 			tbParallel(tb)
 			file, err := fs.Open("foo")
 			if !assert.NoError(tb, err) {
@@ -188,10 +188,7 @@ func TestFileSeek(tb testing.TB, o FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "seek unknown start", func(tb testing.TB) {
-		if o.Constraints.InvalidSeekWhenceUndefined {
-			tb.Skip("Invalid 'whence' value in Seek() is left as undefined behavior")
-		}
+	o.tbRun(tb, "seek unknown start", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -214,7 +211,7 @@ func TestFileSeek(tb testing.TB, o FSOptions) {
 		assert.NoError(tb, f.Close())
 	})
 
-	tbRun(tb, "seek negative offset", func(tb testing.TB) {
+	o.tbRun(tb, "seek negative offset", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -237,7 +234,7 @@ func TestFileSeek(tb testing.TB, o FSOptions) {
 		assert.NoError(tb, f.Close())
 	})
 
-	tbRun(tb, "seek start", func(tb testing.TB) {
+	o.tbRun(tb, "seek start", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -261,7 +258,7 @@ func TestFileSeek(tb testing.TB, o FSOptions) {
 		assert.NoError(tb, f.Close())
 	})
 
-	tbRun(tb, "seek current", func(tb testing.TB) {
+	o.tbRun(tb, "seek current", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -288,7 +285,7 @@ func TestFileSeek(tb testing.TB, o FSOptions) {
 		assert.NoError(tb, f.Close())
 	})
 
-	tbRun(tb, "seek end", func(tb testing.TB) {
+	o.tbRun(tb, "seek end", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -324,7 +321,7 @@ func TestFileWrite(tb testing.TB, o FSOptions) {
 }
 
 func testFileWrite(tb testing.TB, o FSOptions, writer func(hackpadfs.File, []byte) (int, error)) {
-	tbRun(tb, "write-read", func(tb testing.TB) {
+	o.tbRun(tb, "write-read", func(tb testing.TB) {
 		const fileContents = "hello world"
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
@@ -350,7 +347,7 @@ func testFileWrite(tb testing.TB, o FSOptions, writer func(hackpadfs.File, []byt
 		assert.NoError(tb, f.Close())
 	})
 
-	tbRun(tb, "write-truncate-write-read", func(tb testing.TB) {
+	o.tbRun(tb, "write-truncate-write-read", func(tb testing.TB) {
 		const fileContents = "hello world"
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
@@ -388,7 +385,7 @@ func TestFileWriteAt(tb testing.TB, o FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "negative offset", func(tb testing.TB) {
+	o.tbRun(tb, "negative offset", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -415,7 +412,7 @@ func TestFileWriteAt(tb testing.TB, o FSOptions) {
 		}
 	})
 
-	tbRun(tb, "no offset", func(tb testing.TB) {
+	o.tbRun(tb, "no offset", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -443,7 +440,7 @@ func TestFileWriteAt(tb testing.TB, o FSOptions) {
 		assert.NoError(tb, file.Close())
 	})
 
-	tbRun(tb, "offset inside file", func(tb testing.TB) {
+	o.tbRun(tb, "offset inside file", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -475,7 +472,7 @@ func TestFileWriteAt(tb testing.TB, o FSOptions) {
 		assert.NoError(tb, file.Close())
 	})
 
-	tbRun(tb, "offset outside file", func(tb testing.TB) {
+	o.tbRun(tb, "offset outside file", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -514,7 +511,7 @@ func TestFileReadDir(tb testing.TB, o FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "list initial root", func(tb testing.TB) {
+	o.tbRun(tb, "list initial root", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := commit()
 		file, err := fs.Open(".")
@@ -525,7 +522,7 @@ func TestFileReadDir(tb testing.TB, o FSOptions) {
 		assert.NoError(tb, f.Close())
 	})
 
-	tbRun(tb, "list root", func(tb testing.TB) {
+	o.tbRun(tb, "list root", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -549,7 +546,7 @@ func TestFileReadDir(tb testing.TB, o FSOptions) {
 		}, asQuickDirInfos(tb, entries))
 	})
 
-	tbRun(tb, "readdir batches", func(tb testing.TB) {
+	o.tbRun(tb, "readdir batches", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		file, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -585,7 +582,7 @@ func TestFileReadDir(tb testing.TB, o FSOptions) {
 		}, asQuickDirInfos(tb, entriesAll))
 	})
 
-	tbRun(tb, "readdir high N", func(tb testing.TB) {
+	o.tbRun(tb, "readdir high N", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "bar", 0700))
 
@@ -601,7 +598,7 @@ func TestFileReadDir(tb testing.TB, o FSOptions) {
 		)
 	})
 
-	tbRun(tb, "list empty subdirectory", func(tb testing.TB) {
+	o.tbRun(tb, "list empty subdirectory", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
 
@@ -615,7 +612,7 @@ func TestFileReadDir(tb testing.TB, o FSOptions) {
 		assert.Equal(tb, 0, len(entries))
 	})
 
-	tbRun(tb, "list subdirectory", func(tb testing.TB) {
+	o.tbRun(tb, "list subdirectory", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
 		file, err := hackpadfs.Create(setupFS, "foo/bar")
@@ -713,7 +710,7 @@ func TestFileTruncate(tb testing.TB, o FSOptions) {
 			size:        int64(len(fileContents)) * 2,
 		},
 	} {
-		tbRun(tb, tc.description, func(tb testing.TB) {
+		o.tbRun(tb, tc.description, func(tb testing.TB) {
 			setupFS, commit := o.Setup.FS(tb)
 			file, err := hackpadfs.Create(setupFS, "foo")
 			if assert.NoError(tb, err) {

--- a/fstest/file.go
+++ b/fstest/file.go
@@ -543,7 +543,7 @@ func TestFileReadDir(tb testing.TB, o FSOptions) {
 		sort.SliceStable(entries, func(a, b int) bool {
 			return entries[a].Name() < entries[b].Name()
 		})
-		assert.Subset(tb, []quickInfo{
+		o.assertSubsetQuickInfos(tb, []quickInfo{
 			{Name: "bar", Mode: hackpadfs.ModeDir | 0700, IsDir: true},
 			{Name: "foo", Mode: 0666},
 		}, asQuickDirInfos(tb, entries))
@@ -578,8 +578,8 @@ func TestFileReadDir(tb testing.TB, o FSOptions) {
 		entries = append(entries, entries1...)
 		entries = append(entries, entries2...)
 		assert.Equal(tb, 2, len(entries))
-		assert.Subset(tb, asQuickDirInfos(tb, entries), asQuickDirInfos(tb, entriesAll))
-		assert.Subset(tb, []quickInfo{
+		o.assertSubsetQuickInfos(tb, asQuickDirInfos(tb, entries), asQuickDirInfos(tb, entriesAll))
+		o.assertSubsetQuickInfos(tb, []quickInfo{
 			{Name: "bar", Mode: hackpadfs.ModeDir | 0700, IsDir: true},
 			{Name: "foo", Mode: 0666},
 		}, asQuickDirInfos(tb, entriesAll))
@@ -595,7 +595,10 @@ func TestFileReadDir(tb testing.TB, o FSOptions) {
 		f := readDirFile(tb, file)
 		entries, err := f.ReadDir(100000000)
 		assert.NoError(tb, err)
-		assert.Contains(tb, asQuickDirInfos(tb, entries), quickInfo{Name: "bar", Mode: hackpadfs.ModeDir | 0700, IsDir: true})
+		o.assertSubsetQuickInfos(tb,
+			[]quickInfo{{Name: "bar", Mode: hackpadfs.ModeDir | 0700, IsDir: true}},
+			asQuickDirInfos(tb, entries),
+		)
 	})
 
 	tbRun(tb, "list empty subdirectory", func(tb testing.TB) {

--- a/fstest/file_concurrent.go
+++ b/fstest/file_concurrent.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hack-pad/hackpadfs/internal/assert"
 )
 
-func TestConcurrentFileRead(tb testing.TB, options FSOptions) {
-	tbRun(tb, "same file path", func(tb testing.TB) {
-		setupFS, commit := options.Setup.FS(tb)
+func TestConcurrentFileRead(tb testing.TB, o FSOptions) {
+	o.tbRun(tb, "same file path", func(tb testing.TB) {
+		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			_, err := hackpadfs.WriteFile(f, []byte("hello world"))
@@ -31,8 +31,8 @@ func TestConcurrentFileRead(tb testing.TB, options FSOptions) {
 		})
 	})
 
-	tbRun(tb, "different file paths", func(tb testing.TB) {
-		setupFS, commit := options.Setup.FS(tb)
+	o.tbRun(tb, "different file paths", func(tb testing.TB) {
+		setupFS, commit := o.Setup.FS(tb)
 		const fileCount = 10
 		for i := 0; i < fileCount; i++ {
 			f, err := hackpadfs.Create(setupFS, fmt.Sprintf("foo-%d", i))
@@ -57,9 +57,9 @@ func TestConcurrentFileRead(tb testing.TB, options FSOptions) {
 	})
 }
 
-func TestConcurrentFileWrite(tb testing.TB, options FSOptions) {
-	tbRun(tb, "same file path", func(tb testing.TB) {
-		setupFS, commit := options.Setup.FS(tb)
+func TestConcurrentFileWrite(tb testing.TB, o FSOptions) {
+	o.tbRun(tb, "same file path", func(tb testing.TB) {
+		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			assert.NoError(tb, f.Close())
@@ -79,8 +79,8 @@ func TestConcurrentFileWrite(tb testing.TB, options FSOptions) {
 		})
 	})
 
-	tbRun(tb, "different file paths", func(tb testing.TB) {
-		setupFS, commit := options.Setup.FS(tb)
+	o.tbRun(tb, "different file paths", func(tb testing.TB) {
+		setupFS, commit := o.Setup.FS(tb)
 		const fileCount = 10
 		for i := 0; i < fileCount; i++ {
 			f, err := hackpadfs.Create(setupFS, fmt.Sprintf("foo-%d", i))
@@ -104,8 +104,8 @@ func TestConcurrentFileWrite(tb testing.TB, options FSOptions) {
 	})
 }
 
-func TestConcurrentFileStat(tb testing.TB, options FSOptions) {
-	setupFS, commit := options.Setup.FS(tb)
+func TestConcurrentFileStat(tb testing.TB, o FSOptions) {
+	setupFS, commit := o.Setup.FS(tb)
 	f, err := hackpadfs.Create(setupFS, "foo")
 	if assert.NoError(tb, err) {
 		assert.NoError(tb, f.Close())

--- a/fstest/file_concurrent.go
+++ b/fstest/file_concurrent.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hack-pad/hackpadfs/internal/assert"
 )
 
-func TestConcurrentFileRead(tb testing.TB, setup TestSetup) {
+func TestConcurrentFileRead(tb testing.TB, options FSOptions) {
 	tbRun(tb, "same file path", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := options.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			_, err := hackpadfs.WriteFile(f, []byte("hello world"))
@@ -32,7 +32,7 @@ func TestConcurrentFileRead(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "different file paths", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := options.Setup.FS(tb)
 		const fileCount = 10
 		for i := 0; i < fileCount; i++ {
 			f, err := hackpadfs.Create(setupFS, fmt.Sprintf("foo-%d", i))
@@ -57,9 +57,9 @@ func TestConcurrentFileRead(tb testing.TB, setup TestSetup) {
 	})
 }
 
-func TestConcurrentFileWrite(tb testing.TB, setup TestSetup) {
+func TestConcurrentFileWrite(tb testing.TB, options FSOptions) {
 	tbRun(tb, "same file path", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := options.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			assert.NoError(tb, f.Close())
@@ -80,7 +80,7 @@ func TestConcurrentFileWrite(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "different file paths", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := options.Setup.FS(tb)
 		const fileCount = 10
 		for i := 0; i < fileCount; i++ {
 			f, err := hackpadfs.Create(setupFS, fmt.Sprintf("foo-%d", i))
@@ -104,8 +104,8 @@ func TestConcurrentFileWrite(tb testing.TB, setup TestSetup) {
 	})
 }
 
-func TestConcurrentFileStat(tb testing.TB, setup TestSetup) {
-	setupFS, commit := setup.FS(tb)
+func TestConcurrentFileStat(tb testing.TB, options FSOptions) {
+	setupFS, commit := options.Setup.FS(tb)
 	f, err := hackpadfs.Create(setupFS, "foo")
 	if assert.NoError(tb, err) {
 		assert.NoError(tb, f.Close())

--- a/fstest/fs.go
+++ b/fstest/fs.go
@@ -641,7 +641,7 @@ func TestRemove(tb testing.TB, o FSOptions) {
 		err = fs.Remove("foo")
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
-			assert.ErrorIs(tb, hackpadfs.ErrExist, err)
+			assert.ErrorIs(tb, hackpadfs.ErrNotEmpty, err)
 			assert.Equal(tb, "remove", err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}

--- a/fstest/fs.go
+++ b/fstest/fs.go
@@ -123,7 +123,7 @@ func testCreate(tb testing.TB, o FSOptions, createFn func(hackpadfs.FS, string) 
 	_, commit := o.Setup.FS(tb)
 	_, _ = createFn(commit(), "foo") // trigger tb.Skip() for incompatible FS's
 
-	tbRun(tb, "new file", func(tb testing.TB) {
+	o.tbRun(tb, "new file", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := commit()
 		file, err := createFn(fs, "foo")
@@ -140,7 +140,7 @@ func testCreate(tb testing.TB, o FSOptions, createFn func(hackpadfs.FS, string) 
 		}, asQuickInfo(info))
 	})
 
-	tbRun(tb, "existing file", func(tb testing.TB) {
+	o.tbRun(tb, "existing file", func(tb testing.TB) {
 		const fileContents = `hello world`
 		setupFS, commit := o.Setup.FS(tb)
 
@@ -165,7 +165,7 @@ func testCreate(tb testing.TB, o FSOptions, createFn func(hackpadfs.FS, string) 
 		}, asQuickInfo(info))
 	})
 
-	tbRun(tb, "existing directory", func(tb testing.TB) {
+	o.tbRun(tb, "existing directory", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
 		fs := commit()
@@ -178,7 +178,7 @@ func testCreate(tb testing.TB, o FSOptions, createFn func(hackpadfs.FS, string) 
 		}
 	})
 
-	tbRun(tb, "parent directory must exist", func(tb testing.TB) {
+	o.tbRun(tb, "parent directory must exist", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := commit()
 		_, err := createFn(fs, "foo/bar")
@@ -231,7 +231,7 @@ func TestMkdir(tb testing.TB, o FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "fail dir exists", func(tb testing.TB) {
+	o.tbRun(tb, "fail dir exists", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := mkdirFS(tb, commit())
 		assert.NoError(tb, fs.Mkdir("foo", 0600))
@@ -247,7 +247,7 @@ func TestMkdir(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "fail file exists", func(tb testing.TB) {
+	o.tbRun(tb, "fail file exists", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -267,7 +267,7 @@ func TestMkdir(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "create sub dir", func(tb testing.TB) {
+	o.tbRun(tb, "create sub dir", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := mkdirFS(tb, commit())
 		assert.NoError(tb, fs.Mkdir("foo", 0700))
@@ -279,7 +279,7 @@ func TestMkdir(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "only permission bits allowed", func(tb testing.TB) {
+	o.tbRun(tb, "only permission bits allowed", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := mkdirFS(tb, commit())
 		assert.NoError(tb, fs.Mkdir("foo", hackpadfs.ModeSocket|0755))
@@ -289,7 +289,7 @@ func TestMkdir(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "parent directory must exist", func(tb testing.TB) {
+	o.tbRun(tb, "parent directory must exist", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := mkdirFS(tb, commit())
 
@@ -316,7 +316,7 @@ func TestMkdirAll(tb testing.TB, o FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "create one directory", func(tb testing.TB) {
+	o.tbRun(tb, "create one directory", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := mkdirAllFS(tb, commit())
 		assert.NoError(tb, fs.MkdirAll("foo", 0700))
@@ -325,7 +325,7 @@ func TestMkdirAll(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "create multiple directories", func(tb testing.TB) {
+	o.tbRun(tb, "create multiple directories", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := mkdirAllFS(tb, commit())
 		assert.NoError(tb, fs.MkdirAll("foo/bar", 0700))
@@ -335,7 +335,7 @@ func TestMkdirAll(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "all directories exist", func(tb testing.TB) {
+	o.tbRun(tb, "all directories exist", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo/bar", 0644))
@@ -348,7 +348,7 @@ func TestMkdirAll(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "file exists", func(tb testing.TB) {
+	o.tbRun(tb, "file exists", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -368,7 +368,7 @@ func TestMkdirAll(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "illegal permission bits", func(tb testing.TB) {
+	o.tbRun(tb, "illegal permission bits", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := mkdirAllFS(tb, commit())
 		assert.NoError(tb, fs.MkdirAll("foo/bar", hackpadfs.ModeSocket|0777))
@@ -392,7 +392,7 @@ func testOpen(tb testing.TB, o FSOptions, openFn func(hackpadfs.FS, string) (hac
 	_, commit := o.Setup.FS(tb)
 	_, _ = openFn(commit(), "foo") // trigger tb.Skip() for incompatible FS's
 
-	tbRun(tb, "invalid path", func(tb testing.TB) {
+	o.tbRun(tb, "invalid path", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := commit()
 		_, err := openFn(fs, "foo/../bar")
@@ -405,7 +405,7 @@ func testOpen(tb testing.TB, o FSOptions, openFn func(hackpadfs.FS, string) (hac
 		}
 	})
 
-	tbRun(tb, "does not exist", func(tb testing.TB) {
+	o.tbRun(tb, "does not exist", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := commit()
 		_, err := openFn(fs, "foo")
@@ -417,7 +417,7 @@ func testOpen(tb testing.TB, o FSOptions, openFn func(hackpadfs.FS, string) (hac
 		}
 	})
 
-	tbRun(tb, "open file", func(tb testing.TB) {
+	o.tbRun(tb, "open file", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -432,7 +432,7 @@ func testOpen(tb testing.TB, o FSOptions, openFn func(hackpadfs.FS, string) (hac
 		}
 	})
 
-	tbRun(tb, "supports reads", func(tb testing.TB) {
+	o.tbRun(tb, "supports reads", func(tb testing.TB) {
 		const fileContents = `hello world`
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
@@ -456,7 +456,7 @@ func testOpen(tb testing.TB, o FSOptions, openFn func(hackpadfs.FS, string) (hac
 		assert.NoError(tb, f.Close())
 	})
 
-	tbRun(tb, "fails writes", func(tb testing.TB) {
+	o.tbRun(tb, "fails writes", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -486,19 +486,19 @@ func TestOpenFile(tb testing.TB, o FSOptions) {
 		tb.Skip("FS is not an OpenFileFS")
 		return nil
 	}
-	tbRun(tb, "read-only", func(tb testing.TB) {
+	o.tbRun(tb, "read-only", func(tb testing.TB) {
 		testOpen(tb, o, func(fs hackpadfs.FS, name string) (hackpadfs.File, error) {
 			return openFileFS(tb, fs).OpenFile(name, hackpadfs.FlagReadOnly, 0777)
 		})
 	})
 
-	tbRun(tb, "create", func(tb testing.TB) {
+	o.tbRun(tb, "create", func(tb testing.TB) {
 		testCreate(tb, o, func(fs hackpadfs.FS, name string) (hackpadfs.File, error) {
 			return openFileFS(tb, fs).OpenFile(name, hackpadfs.FlagReadWrite|hackpadfs.FlagCreate|hackpadfs.FlagTruncate, 0666)
 		})
 	})
 
-	tbRun(tb, "create illegal perms", func(tb testing.TB) {
+	o.tbRun(tb, "create illegal perms", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := openFileFS(tb, commit())
 		f, err := fs.OpenFile("foo", hackpadfs.FlagReadOnly|hackpadfs.FlagCreate, hackpadfs.ModeSocket|0777)
@@ -510,7 +510,7 @@ func TestOpenFile(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "truncate on existing file", func(tb testing.TB) {
+	o.tbRun(tb, "truncate on existing file", func(tb testing.TB) {
 		const fileContents = "hello world"
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
@@ -528,7 +528,7 @@ func TestOpenFile(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "truncate on non-existent file", func(tb testing.TB) {
+	o.tbRun(tb, "truncate on non-existent file", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := openFileFS(tb, commit())
 		_, err := fs.OpenFile("foo", hackpadfs.FlagTruncate, 0700)
@@ -540,7 +540,7 @@ func TestOpenFile(tb testing.TB, o FSOptions) {
 		}
 	})
 
-	tbRun(tb, "truncate on existing dir", func(tb testing.TB) {
+	o.tbRun(tb, "truncate on existing dir", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
 		fs := openFileFS(tb, commit())
@@ -553,7 +553,7 @@ func TestOpenFile(tb testing.TB, o FSOptions) {
 		}
 	})
 
-	tbRun(tb, "append flag writes to end", func(tb testing.TB) {
+	o.tbRun(tb, "append flag writes to end", func(tb testing.TB) {
 		const (
 			fileContents1 = "hello world"
 			fileContents2 = "sup "
@@ -590,7 +590,7 @@ func TestRemove(tb testing.TB, o FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "remove file", func(tb testing.TB) {
+	o.tbRun(tb, "remove file", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -602,7 +602,7 @@ func TestRemove(tb testing.TB, o FSOptions) {
 		o.tryAssertEqualFS(tb, map[string]fsEntry{}, fs)
 	})
 
-	tbRun(tb, "remove empty dir", func(tb testing.TB) {
+	o.tbRun(tb, "remove empty dir", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
 
@@ -611,7 +611,7 @@ func TestRemove(tb testing.TB, o FSOptions) {
 		o.tryAssertEqualFS(tb, map[string]fsEntry{}, fs)
 	})
 
-	tbRun(tb, "remove non-existing file", func(tb testing.TB) {
+	o.tbRun(tb, "remove non-existing file", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := removeFS(tb, commit())
 		err := fs.Remove("foo")
@@ -624,7 +624,7 @@ func TestRemove(tb testing.TB, o FSOptions) {
 		o.tryAssertEqualFS(tb, map[string]fsEntry{}, fs)
 	})
 
-	tbRun(tb, "remove non-empty dir", func(tb testing.TB) {
+	o.tbRun(tb, "remove non-empty dir", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
 		f, err := hackpadfs.Create(setupFS, "foo/bar")
@@ -660,7 +660,7 @@ func TestRemoveAll(tb testing.TB, o FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "remove file", func(tb testing.TB) {
+	o.tbRun(tb, "remove file", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -672,7 +672,7 @@ func TestRemoveAll(tb testing.TB, o FSOptions) {
 		o.tryAssertEqualFS(tb, map[string]fsEntry{}, fs)
 	})
 
-	tbRun(tb, "remove empty dir", func(tb testing.TB) {
+	o.tbRun(tb, "remove empty dir", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
 
@@ -681,14 +681,14 @@ func TestRemoveAll(tb testing.TB, o FSOptions) {
 		o.tryAssertEqualFS(tb, map[string]fsEntry{}, fs)
 	})
 
-	tbRun(tb, "remove non-existing file", func(tb testing.TB) {
+	o.tbRun(tb, "remove non-existing file", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := removeAllFS(tb, commit())
 		assert.NoError(tb, fs.RemoveAll("foo"))
 		o.tryAssertEqualFS(tb, map[string]fsEntry{}, fs)
 	})
 
-	tbRun(tb, "remove non-empty dir", func(tb testing.TB) {
+	o.tbRun(tb, "remove non-empty dir", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
 		f, err := hackpadfs.Create(setupFS, "foo/bar")
@@ -717,7 +717,7 @@ func TestRename(tb testing.TB, o FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "oldpath does not exist", func(tb testing.TB) {
+	o.tbRun(tb, "oldpath does not exist", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := renameFS(tb, commit())
 		err := fs.Rename("foo", "bar")
@@ -730,7 +730,7 @@ func TestRename(tb testing.TB, o FSOptions) {
 		}
 	})
 
-	tbRun(tb, "inside same directory", func(tb testing.TB) {
+	o.tbRun(tb, "inside same directory", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
 		f, err := hackpadfs.Create(setupFS, "foo/bar")
@@ -746,7 +746,7 @@ func TestRename(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "inside same directory in root", func(tb testing.TB) {
+	o.tbRun(tb, "inside same directory in root", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "bar")
 		if assert.NoError(tb, err) {
@@ -760,7 +760,7 @@ func TestRename(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "same file", func(tb testing.TB) {
+	o.tbRun(tb, "same file", func(tb testing.TB) {
 		const fileContents = `hello world`
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
@@ -779,14 +779,14 @@ func TestRename(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "same directory", func(tb testing.TB) {
+	o.tbRun(tb, "same directory", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
 
 		fs := renameFS(tb, commit())
 		err := fs.Rename("foo", "foo")
 
-		if !o.Constraints.RenameToSelfNoOp && assert.Error(tb, err) {
+		if assert.Error(tb, err) {
 			assert.ErrorIs(tb, hackpadfs.ErrExist, err)
 			switch err := err.(type) {
 			case *hackpadfs.LinkError:
@@ -803,7 +803,7 @@ func TestRename(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "newpath is directory", func(tb testing.TB) {
+	o.tbRun(tb, "newpath is directory", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "bar", 0700))
@@ -828,7 +828,7 @@ func TestRename(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "newpath in root", func(tb testing.TB) {
+	o.tbRun(tb, "newpath in root", func(tb testing.TB) {
 		const fileContents = `hello world`
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
@@ -847,7 +847,7 @@ func TestRename(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "newpath in subdirectory", func(tb testing.TB) {
+	o.tbRun(tb, "newpath in subdirectory", func(tb testing.TB) {
 		const fileContents = `hello world`
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
@@ -866,7 +866,7 @@ func TestRename(tb testing.TB, o FSOptions) {
 		}, fs)
 	})
 
-	tbRun(tb, "non-empty directory", func(tb testing.TB) {
+	o.tbRun(tb, "non-empty directory", func(tb testing.TB) {
 		const fileContents = `hello world`
 		setupFS, commit := o.Setup.FS(tb)
 		assert.NoError(tb, hackpadfs.Mkdir(setupFS, "foo", 0700))
@@ -898,7 +898,7 @@ func TestStat(tb testing.TB, o FSOptions) {
 }
 
 func testStat(tb testing.TB, o FSOptions, stater func(testing.TB, hackpadfs.FS, string) (hackpadfs.FileInfo, error)) {
-	tbRun(tb, "invalid path", func(tb testing.TB) {
+	o.tbRun(tb, "invalid path", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := commit()
 		_, err := stater(tb, fs, "foo/../bar")
@@ -909,7 +909,7 @@ func testStat(tb testing.TB, o FSOptions, stater func(testing.TB, hackpadfs.FS, 
 		}
 	})
 
-	tbRun(tb, "stat root", func(tb testing.TB) {
+	o.tbRun(tb, "stat root", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := commit()
 		info, err := stater(tb, fs, ".")
@@ -918,7 +918,7 @@ func testStat(tb testing.TB, o FSOptions, stater func(testing.TB, hackpadfs.FS, 
 		}
 	})
 
-	tbRun(tb, "stat a file", func(tb testing.TB) {
+	o.tbRun(tb, "stat a file", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -938,7 +938,7 @@ func testStat(tb testing.TB, o FSOptions, stater func(testing.TB, hackpadfs.FS, 
 		})
 	})
 
-	tbRun(tb, "stat a directory", func(tb testing.TB) {
+	o.tbRun(tb, "stat a directory", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		err := hackpadfs.Mkdir(setupFS, "foo", 0755)
 		assert.NoError(tb, err)
@@ -953,7 +953,7 @@ func testStat(tb testing.TB, o FSOptions, stater func(testing.TB, hackpadfs.FS, 
 		}, asQuickInfo(info))
 	})
 
-	tbRun(tb, "stat nested files", func(tb testing.TB) {
+	o.tbRun(tb, "stat nested files", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		err := hackpadfs.Mkdir(setupFS, "foo", 0755)
 		assert.NoError(tb, err)
@@ -997,7 +997,7 @@ func TestChmod(tb testing.TB, o FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "change permission bits", func(tb testing.TB) {
+	o.tbRun(tb, "change permission bits", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -1015,7 +1015,7 @@ func TestChmod(tb testing.TB, o FSOptions) {
 		}, asQuickInfo(info))
 	})
 
-	tbRun(tb, "change symlink target permission bits", func(tb testing.TB) {
+	o.tbRun(tb, "change symlink target permission bits", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		if _, ok := setupFS.(hackpadfs.SymlinkFS); !ok {
 			tb.Skip("FS is not an SymlinkFS")
@@ -1061,7 +1061,7 @@ func TestChtimes(tb testing.TB, o FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "file does not exist", func(tb testing.TB) {
+	o.tbRun(tb, "file does not exist", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := chtimesFS(tb, commit())
 		err := fs.Chtimes("foo", accessTime, modifyTime)
@@ -1073,7 +1073,7 @@ func TestChtimes(tb testing.TB, o FSOptions) {
 		}
 	})
 
-	tbRun(tb, "change access and modify times", func(tb testing.TB) {
+	o.tbRun(tb, "change access and modify times", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
@@ -1103,7 +1103,7 @@ func TestReadFile(tb testing.TB, o FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "not exists", func(tb testing.TB) {
+	o.tbRun(tb, "not exists", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := readFileFS(tb, commit())
 		_, err := fs.ReadFile("foo")
@@ -1115,7 +1115,7 @@ func TestReadFile(tb testing.TB, o FSOptions) {
 		}
 	})
 
-	tbRun(tb, "exists", func(tb testing.TB) {
+	o.tbRun(tb, "exists", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
 		const contents = "hello"
 		f, err := hackpadfs.Create(setupFS, "foo")

--- a/fstest/fs.go
+++ b/fstest/fs.go
@@ -3,7 +3,7 @@ package fstest
 import (
 	// Avoid importing "os" package in fstest if we can, since not all environments may be able to support it.
 	// Not to mention it should compile a little faster. :)
-	"errors"
+
 	"fmt"
 	"io"
 	"testing"
@@ -174,7 +174,7 @@ func testCreate(tb testing.TB, o FSOptions, createFn func(hackpadfs.FS, string) 
 			err := err.(*hackpadfs.PathError)
 			assert.Equal(tb, "open", err.Op)
 			assert.Equal(tb, "foo", err.Path)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrIsDir))
+			assert.ErrorIs(tb, hackpadfs.ErrIsDir, err)
 		}
 	})
 
@@ -186,7 +186,7 @@ func testCreate(tb testing.TB, o FSOptions, createFn func(hackpadfs.FS, string) 
 			err := err.(*hackpadfs.PathError)
 			assert.Equal(tb, "open", err.Op)
 			assert.Equal(tb, "foo/bar", err.Path)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrNotExist))
+			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
 		}
 	})
 }
@@ -238,7 +238,7 @@ func TestMkdir(tb testing.TB, o FSOptions) {
 		err := fs.Mkdir("foo", 0600)
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrExist))
+			assert.ErrorIs(tb, hackpadfs.ErrExist, err)
 			assert.Equal(tb, "mkdir", err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}
@@ -258,7 +258,7 @@ func TestMkdir(tb testing.TB, o FSOptions) {
 		err = fs.Mkdir("foo", 0600)
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrExist))
+			assert.ErrorIs(tb, hackpadfs.ErrExist, err)
 			assert.Equal(tb, "mkdir", err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}
@@ -296,7 +296,7 @@ func TestMkdir(tb testing.TB, o FSOptions) {
 		err := fs.Mkdir("foo/bar", 0755)
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrNotExist))
+			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
 			assert.Equal(tb, "mkdir", err.Op)
 			assert.Equal(tb, "foo/bar", err.Path)
 		}
@@ -359,7 +359,7 @@ func TestMkdirAll(tb testing.TB, o FSOptions) {
 		err = fs.MkdirAll("foo/bar", 0700)
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrNotDir))
+			assert.ErrorIs(tb, hackpadfs.ErrNotDir, err)
 			assert.Equal(tb, "mkdir", err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}
@@ -399,7 +399,7 @@ func testOpen(tb testing.TB, o FSOptions, openFn func(hackpadfs.FS, string) (hac
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
 			tb.Log(err.Err)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrInvalid))
+			assert.ErrorIs(tb, hackpadfs.ErrInvalid, err)
 			assert.Equal(tb, "open", err.Op)
 			assert.Equal(tb, "foo/../bar", err.Path)
 		}
@@ -411,7 +411,7 @@ func testOpen(tb testing.TB, o FSOptions, openFn func(hackpadfs.FS, string) (hac
 		_, err := openFn(fs, "foo")
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrNotExist))
+			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
 			assert.Equal(tb, "open", err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}
@@ -534,7 +534,7 @@ func TestOpenFile(tb testing.TB, o FSOptions) {
 		_, err := fs.OpenFile("foo", hackpadfs.FlagTruncate, 0700)
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrNotExist))
+			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
 			assert.Equal(tb, "open", err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}
@@ -547,7 +547,7 @@ func TestOpenFile(tb testing.TB, o FSOptions) {
 		_, err := fs.OpenFile("foo", hackpadfs.FlagTruncate, 0700)
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrIsDir))
+			assert.ErrorIs(tb, hackpadfs.ErrIsDir, err)
 			assert.Equal(tb, "open", err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}
@@ -617,7 +617,7 @@ func TestRemove(tb testing.TB, o FSOptions) {
 		err := fs.Remove("foo")
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrNotExist))
+			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
 			assert.Equal(tb, "remove", err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}
@@ -636,7 +636,7 @@ func TestRemove(tb testing.TB, o FSOptions) {
 		err = fs.Remove("foo")
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrExist))
+			assert.ErrorIs(tb, hackpadfs.ErrExist, err)
 			assert.Equal(tb, "remove", err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}
@@ -723,7 +723,7 @@ func TestRename(tb testing.TB, o FSOptions) {
 		err := fs.Rename("foo", "bar")
 		if assert.IsType(tb, &hackpadfs.LinkError{}, err) {
 			err := err.(*hackpadfs.LinkError)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrNotExist))
+			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
 			assert.Equal(tb, "rename", err.Op)
 			assert.Equal(tb, "foo", err.Old)
 			assert.Equal(tb, "bar", err.New)
@@ -787,7 +787,7 @@ func TestRename(tb testing.TB, o FSOptions) {
 		err := fs.Rename("foo", "foo")
 
 		if assert.Error(tb, err) {
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrExist))
+			assert.ErrorIs(tb, hackpadfs.ErrExist, err)
 			switch err := err.(type) {
 			case *hackpadfs.LinkError:
 				assert.Equal(tb, "rename", err.Op)
@@ -811,7 +811,7 @@ func TestRename(tb testing.TB, o FSOptions) {
 		fs := renameFS(tb, commit())
 		err := fs.Rename("foo", "bar")
 		if assert.Error(tb, err) {
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrExist))
+			assert.ErrorIs(tb, hackpadfs.ErrExist, err)
 			switch err := err.(type) {
 			case *hackpadfs.LinkError:
 				assert.Equal(tb, "rename", err.Op)
@@ -905,7 +905,7 @@ func testStat(tb testing.TB, o FSOptions, stater func(testing.TB, hackpadfs.FS, 
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
 			assert.Equal(tb, "foo/../bar", err.Path)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrInvalid))
+			assert.ErrorIs(tb, hackpadfs.ErrInvalid, err)
 		}
 	})
 
@@ -1067,7 +1067,7 @@ func TestChtimes(tb testing.TB, o FSOptions) {
 		err := fs.Chtimes("foo", accessTime, modifyTime)
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrNotExist))
+			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
 			assert.Equal(tb, "chtimes", err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}
@@ -1109,7 +1109,7 @@ func TestReadFile(tb testing.TB, o FSOptions) {
 		_, err := fs.ReadFile("foo")
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
-			assert.Equal(tb, true, errors.Is(err, hackpadfs.ErrNotExist))
+			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
 			assert.Equal(tb, "open", err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}

--- a/fstest/fs.go
+++ b/fstest/fs.go
@@ -786,7 +786,7 @@ func TestRename(tb testing.TB, o FSOptions) {
 		fs := renameFS(tb, commit())
 		err := fs.Rename("foo", "foo")
 
-		if assert.Error(tb, err) {
+		if !o.Constraints.RenameToSelfNoOp && assert.Error(tb, err) {
 			assert.ErrorIs(tb, hackpadfs.ErrExist, err)
 			switch err := err.(type) {
 			case *hackpadfs.LinkError:

--- a/fstest/fs_concurrent.go
+++ b/fstest/fs_concurrent.go
@@ -27,9 +27,9 @@ func concurrentTasks(count int, task func(int)) {
 	wg.Wait()
 }
 
-func TestConcurrentCreate(tb testing.TB, setup TestSetup) {
+func TestConcurrentCreate(tb testing.TB, options FSOptions) {
 	createFS := func(tb testing.TB) hackpadfs.CreateFS {
-		_, commit := setup.FS(tb)
+		_, commit := options.Setup.FS(tb)
 		if fs, ok := commit().(hackpadfs.CreateFS); ok {
 			return fs
 		}
@@ -58,9 +58,9 @@ func TestConcurrentCreate(tb testing.TB, setup TestSetup) {
 	})
 }
 
-func TestConcurrentOpenFileCreate(tb testing.TB, setup TestSetup) {
+func TestConcurrentOpenFileCreate(tb testing.TB, options FSOptions) {
 	openFileFS := func(tb testing.TB) hackpadfs.OpenFileFS {
-		_, commit := setup.FS(tb)
+		_, commit := options.Setup.FS(tb)
 		if fs, ok := commit().(hackpadfs.OpenFileFS); ok {
 			return fs
 		}
@@ -89,7 +89,7 @@ func TestConcurrentOpenFileCreate(tb testing.TB, setup TestSetup) {
 	})
 }
 
-func TestConcurrentRemove(tb testing.TB, setup TestSetup) {
+func TestConcurrentRemove(tb testing.TB, options FSOptions) {
 	removeFS := func(tb testing.TB, commit func() hackpadfs.FS) hackpadfs.RemoveFS {
 		if fs, ok := commit().(hackpadfs.RemoveFS); ok {
 			return fs
@@ -99,7 +99,7 @@ func TestConcurrentRemove(tb testing.TB, setup TestSetup) {
 	}
 
 	tbRun(tb, "same file path", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := options.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			assert.NoError(tb, f.Close())
@@ -112,7 +112,7 @@ func TestConcurrentRemove(tb testing.TB, setup TestSetup) {
 	})
 
 	tbRun(tb, "different file paths", func(tb testing.TB) {
-		setupFS, commit := setup.FS(tb)
+		setupFS, commit := options.Setup.FS(tb)
 		const fileCount = defaultConcurrentTasks
 		for i := 0; i < fileCount; i++ {
 			f, err := hackpadfs.Create(setupFS, fmt.Sprintf("foo-%d", i))
@@ -128,9 +128,9 @@ func TestConcurrentRemove(tb testing.TB, setup TestSetup) {
 	})
 }
 
-func TestConcurrentMkdir(tb testing.TB, setup TestSetup) {
+func TestConcurrentMkdir(tb testing.TB, options FSOptions) {
 	mkdirFS := func(tb testing.TB) hackpadfs.MkdirFS {
-		_, commit := setup.FS(tb)
+		_, commit := options.Setup.FS(tb)
 		if fs, ok := commit().(hackpadfs.MkdirFS); ok {
 			return fs
 		}
@@ -155,9 +155,9 @@ func TestConcurrentMkdir(tb testing.TB, setup TestSetup) {
 	})
 }
 
-func TestConcurrentMkdirAll(tb testing.TB, setup TestSetup) {
+func TestConcurrentMkdirAll(tb testing.TB, options FSOptions) {
 	mkdirAllFS := func(tb testing.TB) hackpadfs.MkdirAllFS {
-		_, commit := setup.FS(tb)
+		_, commit := options.Setup.FS(tb)
 		if fs, ok := commit().(hackpadfs.MkdirAllFS); ok {
 			return fs
 		}

--- a/fstest/fs_concurrent.go
+++ b/fstest/fs_concurrent.go
@@ -27,9 +27,9 @@ func concurrentTasks(count int, task func(int)) {
 	wg.Wait()
 }
 
-func TestConcurrentCreate(tb testing.TB, options FSOptions) {
+func TestConcurrentCreate(tb testing.TB, o FSOptions) {
 	createFS := func(tb testing.TB) hackpadfs.CreateFS {
-		_, commit := options.Setup.FS(tb)
+		_, commit := o.Setup.FS(tb)
 		if fs, ok := commit().(hackpadfs.CreateFS); ok {
 			return fs
 		}
@@ -37,7 +37,7 @@ func TestConcurrentCreate(tb testing.TB, options FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "same file path", func(tb testing.TB) {
+	o.tbRun(tb, "same file path", func(tb testing.TB) {
 		fs := createFS(tb)
 		concurrentTasks(0, func(i int) {
 			f, err := fs.Create("foo")
@@ -47,7 +47,7 @@ func TestConcurrentCreate(tb testing.TB, options FSOptions) {
 		})
 	})
 
-	tbRun(tb, "different file paths", func(tb testing.TB) {
+	o.tbRun(tb, "different file paths", func(tb testing.TB) {
 		fs := createFS(tb)
 		concurrentTasks(0, func(i int) {
 			f, err := fs.Create(fmt.Sprintf("foo-%d", i))
@@ -58,9 +58,9 @@ func TestConcurrentCreate(tb testing.TB, options FSOptions) {
 	})
 }
 
-func TestConcurrentOpenFileCreate(tb testing.TB, options FSOptions) {
+func TestConcurrentOpenFileCreate(tb testing.TB, o FSOptions) {
 	openFileFS := func(tb testing.TB) hackpadfs.OpenFileFS {
-		_, commit := options.Setup.FS(tb)
+		_, commit := o.Setup.FS(tb)
 		if fs, ok := commit().(hackpadfs.OpenFileFS); ok {
 			return fs
 		}
@@ -68,7 +68,7 @@ func TestConcurrentOpenFileCreate(tb testing.TB, options FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "same file path", func(tb testing.TB) {
+	o.tbRun(tb, "same file path", func(tb testing.TB) {
 		fs := openFileFS(tb)
 		concurrentTasks(0, func(i int) {
 			f, err := fs.OpenFile("foo", hackpadfs.FlagReadWrite|hackpadfs.FlagCreate|hackpadfs.FlagTruncate, 0666)
@@ -78,7 +78,7 @@ func TestConcurrentOpenFileCreate(tb testing.TB, options FSOptions) {
 		})
 	})
 
-	tbRun(tb, "different file paths", func(tb testing.TB) {
+	o.tbRun(tb, "different file paths", func(tb testing.TB) {
 		fs := openFileFS(tb)
 		concurrentTasks(0, func(i int) {
 			f, err := fs.OpenFile(fmt.Sprintf("foo-%d", i), hackpadfs.FlagReadWrite|hackpadfs.FlagCreate|hackpadfs.FlagTruncate, 0666)
@@ -89,7 +89,7 @@ func TestConcurrentOpenFileCreate(tb testing.TB, options FSOptions) {
 	})
 }
 
-func TestConcurrentRemove(tb testing.TB, options FSOptions) {
+func TestConcurrentRemove(tb testing.TB, o FSOptions) {
 	removeFS := func(tb testing.TB, commit func() hackpadfs.FS) hackpadfs.RemoveFS {
 		if fs, ok := commit().(hackpadfs.RemoveFS); ok {
 			return fs
@@ -98,8 +98,8 @@ func TestConcurrentRemove(tb testing.TB, options FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "same file path", func(tb testing.TB) {
-		setupFS, commit := options.Setup.FS(tb)
+	o.tbRun(tb, "same file path", func(tb testing.TB) {
+		setupFS, commit := o.Setup.FS(tb)
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			assert.NoError(tb, f.Close())
@@ -111,8 +111,8 @@ func TestConcurrentRemove(tb testing.TB, options FSOptions) {
 		})
 	})
 
-	tbRun(tb, "different file paths", func(tb testing.TB) {
-		setupFS, commit := options.Setup.FS(tb)
+	o.tbRun(tb, "different file paths", func(tb testing.TB) {
+		setupFS, commit := o.Setup.FS(tb)
 		const fileCount = defaultConcurrentTasks
 		for i := 0; i < fileCount; i++ {
 			f, err := hackpadfs.Create(setupFS, fmt.Sprintf("foo-%d", i))
@@ -128,9 +128,9 @@ func TestConcurrentRemove(tb testing.TB, options FSOptions) {
 	})
 }
 
-func TestConcurrentMkdir(tb testing.TB, options FSOptions) {
+func TestConcurrentMkdir(tb testing.TB, o FSOptions) {
 	mkdirFS := func(tb testing.TB) hackpadfs.MkdirFS {
-		_, commit := options.Setup.FS(tb)
+		_, commit := o.Setup.FS(tb)
 		if fs, ok := commit().(hackpadfs.MkdirFS); ok {
 			return fs
 		}
@@ -138,7 +138,7 @@ func TestConcurrentMkdir(tb testing.TB, options FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "same file path", func(tb testing.TB) {
+	o.tbRun(tb, "same file path", func(tb testing.TB) {
 		fs := mkdirFS(tb)
 		concurrentTasks(0, func(i int) {
 			err := fs.Mkdir("foo", 0777)
@@ -146,7 +146,7 @@ func TestConcurrentMkdir(tb testing.TB, options FSOptions) {
 		})
 	})
 
-	tbRun(tb, "different file paths", func(tb testing.TB) {
+	o.tbRun(tb, "different file paths", func(tb testing.TB) {
 		fs := mkdirFS(tb)
 		concurrentTasks(0, func(i int) {
 			err := fs.Mkdir(fmt.Sprintf("foo-%d", i), 0777)
@@ -155,9 +155,9 @@ func TestConcurrentMkdir(tb testing.TB, options FSOptions) {
 	})
 }
 
-func TestConcurrentMkdirAll(tb testing.TB, options FSOptions) {
+func TestConcurrentMkdirAll(tb testing.TB, o FSOptions) {
 	mkdirAllFS := func(tb testing.TB) hackpadfs.MkdirAllFS {
-		_, commit := options.Setup.FS(tb)
+		_, commit := o.Setup.FS(tb)
 		if fs, ok := commit().(hackpadfs.MkdirAllFS); ok {
 			return fs
 		}
@@ -165,7 +165,7 @@ func TestConcurrentMkdirAll(tb testing.TB, options FSOptions) {
 		return nil
 	}
 
-	tbRun(tb, "same file path", func(tb testing.TB) {
+	o.tbRun(tb, "same file path", func(tb testing.TB) {
 		fs := mkdirAllFS(tb)
 		concurrentTasks(0, func(i int) {
 			err := fs.MkdirAll("foo", 0777)
@@ -173,7 +173,7 @@ func TestConcurrentMkdirAll(tb testing.TB, options FSOptions) {
 		})
 	})
 
-	tbRun(tb, "different file paths", func(tb testing.TB) {
+	o.tbRun(tb, "different file paths", func(tb testing.TB) {
 		fs := mkdirAllFS(tb)
 		concurrentTasks(0, func(i int) {
 			err := fs.MkdirAll(fmt.Sprintf("foo-%d", i), 0777)

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -62,7 +62,7 @@ func (fn TestSetupFunc) FS(tb testing.TB) (SetupFS, func() hackpadfs.FS) {
 	return fn(tb)
 }
 
-// Contraints limits tests to a reduced set of assertions due to non-standard behavior. Avoid setting any of these.
+// Constraints limits tests to a reduced set of assertions due to non-standard behavior. Avoid setting any of these.
 type Constraints struct {
 	// FileModeMask disables mode checks on the specified bits. Defaults to checking all bits (0).
 	FileModeMask hackpadfs.FileMode

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -54,12 +54,14 @@ func (fn TestSetupFunc) FS(tb testing.TB) (SetupFS, func() hackpadfs.FS) {
 	return fn(tb)
 }
 
-// Contraints limits tests to a reduced set of assertions
+// Contraints limits tests to a reduced set of assertions due to non-standard behavior. Avoid setting any of these.
 type Constraints struct {
 	// FileModeMask disables mode checks on the specified bits. Defaults to checking all bits (0).
 	FileModeMask hackpadfs.FileMode
 	// InvalidSeekWhenceUndefined is true when the behavior of Seek() with an invalid 'whence' is not defined. Windows seems to be the only candidate where no error occurs.
 	InvalidSeekWhenceUndefined bool
+	// RenameToSelfNoOp is true when renaming a file to an identical path should be a no-op, instead of an error.
+	RenameToSelfNoOp bool
 }
 
 func setupOptions(options *FSOptions) error {

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -24,8 +24,10 @@ type FSOptions struct {
 	// However, in more niche file systems like a read-only FS, it is necessary to commit files to a normal FS, then copy them into a read-only store.
 	Setup TestSetup
 
-	// Contraints limits tests to a reduced set of assertions.
+	// Contraints limits tests to a reduced set of assertions. Avoid setting any of these options.
 	// For example, setting FileModeMask limits FileMode assertions on a file's Stat() result.
+	//
+	// NOTE: This MUST NOT be used lightly. Any custom constraints severely impairs the quality of a standardized file system.
 	Constraints Constraints
 
 	// ShouldSkip determines if the current test with features defined by 'facets' should be skipped.
@@ -67,7 +69,7 @@ type Constraints struct {
 }
 
 // Facets contains details for the current test.
-// Used in FSOptions.ShouldSkip() inspect and skip tests that should not apply.
+// Used in FSOptions.ShouldSkip() to inspect and skip tests that should not apply to this FS.
 type Facets struct {
 	// Name is the full name of the current test
 	Name string

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -133,7 +133,7 @@ func FS(tb testing.TB, options FSOptions) {
 		tb.Fatal(err)
 		return
 	}
-	options.tbRun(tb, options.Name, func(tb testing.TB) {
+	options.tbRun(tb, options.Name+"_FS", func(tb testing.TB) {
 		tbParallel(tb)
 		tb.Helper()
 		runFS(tb, options)
@@ -149,7 +149,7 @@ func File(tb testing.TB, options FSOptions) {
 		tb.Fatal(err)
 		return
 	}
-	options.tbRun(tb, options.Name, func(tb testing.TB) {
+	options.tbRun(tb, options.Name+"_File", func(tb testing.TB) {
 		tbParallel(tb)
 		tb.Helper()
 		runFile(tb, options)

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -58,6 +58,8 @@ func (fn TestSetupFunc) FS(tb testing.TB) (SetupFS, func() hackpadfs.FS) {
 type Constraints struct {
 	// FileModeMask disables mode checks on the specified bits. Defaults to checking all bits (0).
 	FileModeMask hackpadfs.FileMode
+	// InvalidSeekWhenceUndefined is true when the behavior of Seek() with an invalid 'whence' is not defined. Windows seems to be the only candidate where no error occurs.
+	InvalidSeekWhenceUndefined bool
 }
 
 func setupOptions(options *FSOptions) error {

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -2,6 +2,7 @@ package assert
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -224,4 +225,13 @@ func subset(tb testing.TB, expected, actual interface{}) bool {
 		tb.Errorf("Invalid subset type. Expected slice, got: %T", expected)
 		return false
 	}
+}
+
+func ErrorIs(tb testing.TB, target, err error) bool {
+	tb.Helper()
+	if errors.Is(err, target) {
+		return true
+	}
+	tb.Errorf("Error must match target:\nExpected: %s\nActual:   %s", target, err)
+	return false
 }

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -227,6 +227,7 @@ func subset(tb testing.TB, expected, actual interface{}) bool {
 	}
 }
 
+// ErrorIs asserts 'err' matches the expected 'target'. Uses errors.Is().
 func ErrorIs(tb testing.TB, target, err error) bool {
 	tb.Helper()
 	if errors.Is(err, target) {

--- a/os/errors_other.go
+++ b/os/errors_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+// +build !windows
+
+package os
+
+// wrapNonStandardErrors maps an operating system-specific error to a common type.
+// Only implemented for built-in standard library os errors, no other custom FS errors.
+func (fs *FS) wrapNonStandardErrors(err error) error {
+	return err
+}

--- a/os/errors_windows.go
+++ b/os/errors_windows.go
@@ -1,0 +1,64 @@
+//go:build windows
+// +build windows
+
+package os
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+
+	"github.com/hack-pad/hackpadfs"
+)
+
+// wrapNonStandardErrors maps an operating system-specific error to a common type.
+// Only implemented for built-in standard library os errors, no other custom FS errors.
+func (fs *FS) wrapNonStandardErrors(err error) error {
+	switch e := err.(type) {
+	case *hackpadfs.PathError:
+		errCopy := *e
+		errCopy.Err = fs.mapNonStandardError(errCopy.Err)
+		err = &errCopy
+	case *hackpadfs.LinkError:
+		errCopy := *e
+		errCopy.Err = fs.mapNonStandardError(errCopy.Err)
+		err = &errCopy
+	default:
+		err = fs.mapNonStandardError(err)
+	}
+	return err
+}
+
+func (fs *FS) mapNonStandardError(err error) error {
+	errno, ok := err.(syscall.Errno)
+	if !ok {
+		return err
+	}
+	// Values from https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
+	const (
+		ERROR_NEGATIVE_SEEK = syscall.Errno(0x83)
+	)
+	switch errno {
+	case ERROR_NEGATIVE_SEEK:
+		return &mappedErr{hackpadfs.ErrInvalid, errno}
+	default:
+		return err
+	}
+}
+
+type mappedErr struct {
+	normalized error
+	original   error
+}
+
+func (m *mappedErr) Error() string {
+	return fmt.Sprintf("%s: %s", m.normalized.Error(), m.original.Error())
+}
+
+func (m *mappedErr) Is(err error) bool {
+	return errors.Is(err, m.normalized)
+}
+
+func (m *mappedErr) Unwrap() error {
+	return m.original
+}

--- a/os/errors_windows.go
+++ b/os/errors_windows.go
@@ -37,10 +37,13 @@ func (fs *FS) mapNonStandardError(err error) error {
 	// Values from https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
 	const (
 		ERROR_NEGATIVE_SEEK = syscall.Errno(0x83)
+		ERROR_DIR_NOT_EMPTY = syscall.Errno(0x91)
 	)
 	switch errno {
 	case ERROR_NEGATIVE_SEEK:
 		return &mappedErr{hackpadfs.ErrInvalid, errno}
+	case ERROR_DIR_NOT_EMPTY:
+		return &mappedErr{hackpadfs.ErrNotEmpty, errno}
 	default:
 		return err
 	}

--- a/os/file.go
+++ b/os/file.go
@@ -19,16 +19,16 @@ func (fs *FS) wrapFile(f *os.File) hackpadfs.File {
 
 // Chmod implements hackpadfs.ChmoderFile
 func (f *file) Chmod(mode hackpadfs.FileMode) error {
-	return f.fs.wrapRelPathErr(f.osFile.Chmod(mode))
+	return f.fs.wrapErr(f.osFile.Chmod(mode))
 }
 
 // Chown implements hackpadfs.ChownerFile
 func (f *file) Chown(uid, gid int) error {
-	return f.fs.wrapRelPathErr(f.osFile.Chown(uid, gid))
+	return f.fs.wrapErr(f.osFile.Chown(uid, gid))
 }
 
 func (f *file) Close() error {
-	return f.fs.wrapRelPathErr(f.osFile.Close())
+	return f.fs.wrapErr(f.osFile.Close())
 }
 
 // Name returns this file's name.
@@ -38,69 +38,69 @@ func (f *file) Name() string {
 
 func (f *file) Read(b []byte) (n int, err error) {
 	n, err = f.osFile.Read(b)
-	return n, f.fs.wrapRelPathErr(err)
+	return n, f.fs.wrapErr(err)
 }
 
 func (f *file) ReadAt(b []byte, off int64) (n int, err error) {
 	n, err = f.osFile.ReadAt(b, off)
-	return n, f.fs.wrapRelPathErr(err)
+	return n, f.fs.wrapErr(err)
 }
 
 func (f *file) ReadDir(n int) ([]hackpadfs.DirEntry, error) {
 	entries, err := f.osFile.ReadDir(n)
-	return entries, f.fs.wrapRelPathErr(err)
+	return entries, f.fs.wrapErr(err)
 }
 
 func (f *file) ReadFrom(r io.Reader) (n int64, err error) {
 	n, err = f.osFile.ReadFrom(r)
-	return n, f.fs.wrapRelPathErr(err)
+	return n, f.fs.wrapErr(err)
 }
 
 // Seek implements hackpadfs.SeekerFile
 func (f *file) Seek(offset int64, whence int) (ret int64, err error) {
 	ret, err = f.osFile.Seek(offset, whence)
-	return ret, f.fs.wrapRelPathErr(err)
+	return ret, f.fs.wrapErr(err)
 }
 
 func (f *file) SetDeadline(t time.Time) error {
-	return f.fs.wrapRelPathErr(f.osFile.SetDeadline(t))
+	return f.fs.wrapErr(f.osFile.SetDeadline(t))
 }
 
 func (f *file) SetReadDeadline(t time.Time) error {
-	return f.fs.wrapRelPathErr(f.osFile.SetReadDeadline(t))
+	return f.fs.wrapErr(f.osFile.SetReadDeadline(t))
 }
 
 func (f *file) SetWriteDeadline(t time.Time) error {
-	return f.fs.wrapRelPathErr(f.osFile.SetWriteDeadline(t))
+	return f.fs.wrapErr(f.osFile.SetWriteDeadline(t))
 }
 
 // Stat implements hackpadfs.StaterFile
 func (f *file) Stat() (hackpadfs.FileInfo, error) {
 	info, err := f.osFile.Stat()
-	return info, f.fs.wrapRelPathErr(err)
+	return info, f.fs.wrapErr(err)
 }
 
 // Sync implements hackpadfs.SycnerFile
 func (f *file) Sync() error {
-	return f.fs.wrapRelPathErr(f.osFile.Sync())
+	return f.fs.wrapErr(f.osFile.Sync())
 }
 
 // Truncate implements hackpadfs.TruncaterFile
 func (f *file) Truncate(size int64) error {
-	return f.fs.wrapRelPathErr(f.osFile.Truncate(size))
+	return f.fs.wrapErr(f.osFile.Truncate(size))
 }
 
 func (f *file) Write(b []byte) (n int, err error) {
 	n, err = f.osFile.Write(b)
-	return n, f.fs.wrapRelPathErr(err)
+	return n, f.fs.wrapErr(err)
 }
 
 func (f *file) WriteAt(b []byte, off int64) (n int, err error) {
 	n, err = f.osFile.WriteAt(b, off)
-	return n, f.fs.wrapRelPathErr(err)
+	return n, f.fs.wrapErr(err)
 }
 
 func (f *file) WriteString(s string) (n int, err error) {
 	n, err = f.osFile.WriteString(s)
-	return n, f.fs.wrapRelPathErr(err)
+	return n, f.fs.wrapErr(err)
 }

--- a/os/fs.go
+++ b/os/fs.go
@@ -94,18 +94,23 @@ func (fs *FS) getVolumeName(goos string) string {
 
 // wrapRelPathErr restores path names to the caller's path names, without the root path prefix
 func (fs *FS) wrapRelPathErr(err error) error {
+	rootedPath, rootedErr := fs.rootedPath("", ".")
+	if rootedErr != nil {
+		panic(rootedErr)
+	}
+	separator := string(filepath.Separator)
 	switch e := err.(type) {
 	case *hackpadfs.PathError:
 		errCopy := *e
-		errCopy.Path = strings.TrimPrefix(errCopy.Path, path.Join("/", fs.root))
-		errCopy.Path = strings.TrimPrefix(errCopy.Path, "/")
+		errCopy.Path = strings.TrimPrefix(errCopy.Path, rootedPath)
+		errCopy.Path = strings.TrimPrefix(errCopy.Path, separator)
 		err = &errCopy
 	case *os.LinkError:
 		errCopy := &hackpadfs.LinkError{Op: e.Op, Old: e.Old, New: e.New, Err: e.Err}
-		errCopy.Old = strings.TrimPrefix(errCopy.Old, path.Join("/", fs.root))
-		errCopy.Old = strings.TrimPrefix(errCopy.Old, "/")
-		errCopy.New = strings.TrimPrefix(errCopy.New, path.Join("/", fs.root))
-		errCopy.New = strings.TrimPrefix(errCopy.New, "/")
+		errCopy.Old = strings.TrimPrefix(errCopy.Old, rootedPath)
+		errCopy.Old = strings.TrimPrefix(errCopy.Old, separator)
+		errCopy.New = strings.TrimPrefix(errCopy.New, rootedPath)
+		errCopy.New = strings.TrimPrefix(errCopy.New, separator)
 		err = errCopy
 	}
 	return err

--- a/os/fs.go
+++ b/os/fs.go
@@ -105,19 +105,25 @@ func (fs *FS) wrapRelPathErr(err error) error {
 	if rootedErr != nil {
 		panic(rootedErr)
 	}
-	separator := string(filepath.Separator)
+	const (
+		separator = string(filepath.Separator)
+		slash     = "/"
+	)
 	switch e := err.(type) {
 	case *hackpadfs.PathError:
 		errCopy := *e
 		errCopy.Path = strings.TrimPrefix(errCopy.Path, rootedPath)
-		errCopy.Path = strings.TrimPrefix(errCopy.Path, separator)
+		errCopy.Path = strings.ReplaceAll(errCopy.Path, separator, slash)
+		errCopy.Path = strings.TrimPrefix(errCopy.Path, slash)
 		err = &errCopy
 	case *os.LinkError:
 		errCopy := &hackpadfs.LinkError{Op: e.Op, Old: e.Old, New: e.New, Err: e.Err}
 		errCopy.Old = strings.TrimPrefix(errCopy.Old, rootedPath)
-		errCopy.Old = strings.TrimPrefix(errCopy.Old, separator)
+		errCopy.Old = strings.ReplaceAll(errCopy.Old, separator, slash)
+		errCopy.Old = strings.TrimPrefix(errCopy.Old, slash)
 		errCopy.New = strings.TrimPrefix(errCopy.New, rootedPath)
-		errCopy.New = strings.TrimPrefix(errCopy.New, separator)
+		errCopy.New = strings.ReplaceAll(errCopy.New, separator, slash)
+		errCopy.New = strings.TrimPrefix(errCopy.New, slash)
 		err = errCopy
 	}
 	return err

--- a/os/fs.go
+++ b/os/fs.go
@@ -14,7 +14,6 @@ import (
 )
 
 const (
-	goosLinux   = "linux"
 	goosWindows = "windows"
 )
 

--- a/os/fs_test.go
+++ b/os/fs_test.go
@@ -126,6 +126,7 @@ func TestFSTest(t *testing.T) {
 	var constraints fstest.Constraints
 	if runtime.GOOS == goosWindows {
 		constraints.FileModeMask = 0200
+		constraints.InvalidSeekWhenceUndefined = true
 	}
 
 	options := fstest.FSOptions{

--- a/os/fs_test.go
+++ b/os/fs_test.go
@@ -4,12 +4,116 @@
 package os
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/hack-pad/hackpadfs/fstest"
 	"github.com/hack-pad/hackpadfs/internal/assert"
 )
+
+func TestRootedPathGOOS(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		root        string
+		volumeName  string
+		goos        string
+		name        string
+		expectPath  string
+		expectErr   string
+	}{
+		{
+			description: "root path unix",
+			goos:        goosLinux,
+			name:        ".",
+			expectPath:  "/",
+		},
+		{
+			description: "root path windows",
+			goos:        goosWindows,
+			name:        ".",
+			expectPath:  `C:\`,
+		},
+		{
+			description: "sub path unix",
+			goos:        goosLinux,
+			name:        "foo",
+			expectPath:  "/foo",
+		},
+		{
+			description: "sub path windows",
+			goos:        goosWindows,
+			name:        "foo",
+			expectPath:  `C:\foo`,
+		},
+		{
+			description: "root sub path unix",
+			root:        "foo",
+			goos:        goosLinux,
+			name:        "bar",
+			expectPath:  "/foo/bar",
+		},
+		{
+			description: "root sub path windows",
+			root:        "foo",
+			goos:        goosWindows,
+			name:        "bar",
+			expectPath:  `C:\foo\bar`,
+		},
+		{
+			description: "letter volume path windows",
+			volumeName:  `D:`,
+			goos:        goosWindows,
+			name:        "foo",
+			expectPath:  `D:\foo`,
+		},
+		{
+			description: "letter volume sub path windows",
+			root:        "foo",
+			volumeName:  `D:`,
+			goos:        goosWindows,
+			name:        "bar",
+			expectPath:  `D:\foo\bar`,
+		},
+		{
+			description: "UNC volume path windows",
+			volumeName:  `\\some-host\share`,
+			goos:        goosWindows,
+			name:        "foo",
+			expectPath:  `\\some-host\share\foo`,
+		},
+		{
+			description: "UNC volume sub path windows",
+			root:        "foo",
+			volumeName:  `\\some-host\share`,
+			goos:        goosWindows,
+			name:        "bar",
+			expectPath:  `\\some-host\share\foo\bar`,
+		},
+	} {
+		tc := tc // enable parallel sub-tests
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+			fs := &FS{
+				root:       tc.root,
+				volumeName: tc.volumeName,
+			}
+			sep := '/'
+			if tc.goos == goosWindows {
+				sep = '\\'
+			}
+			path, err := fs.rootedPathGOOS(tc.goos, sep, "test", tc.name)
+			if tc.expectErr != "" {
+				if assert.Error(t, err) {
+					assert.Equal(t, tc.expectErr, err.Error())
+				}
+				return
+			}
+			assert.Equal(t, tc.expectPath, path)
+			assert.Zero(t, err)
+		})
+	}
+}
 
 func TestFSTest(t *testing.T) {
 	t.Parallel()
@@ -21,13 +125,24 @@ func TestFSTest(t *testing.T) {
 	options := fstest.FSOptions{
 		Name: "osfs.FS",
 		TestFS: func(tb testing.TB) fstest.SetupFS {
+			fs := NewFS()
 			dir := tb.TempDir()
-			dir = strings.TrimPrefix(dir, "/") // TODO support Windows root path
-			fs, err := NewFS().Sub(dir)
+			volumeName := filepath.VolumeName(dir)
+			if volumeName != "" {
+				subvFS, err := fs.SubVolume(volumeName)
+				if !assert.NoError(tb, err) {
+					tb.FailNow()
+				}
+				fs = subvFS.(*FS)
+				dir = dir[len(volumeName)+1:]
+			} else {
+				dir = strings.TrimPrefix(dir, "/")
+			}
+			subFS, err := fs.Sub(dir)
 			if !assert.NoError(tb, err) {
 				tb.FailNow()
 			}
-			return fs.(*FS)
+			return subFS.(*FS)
 		},
 	}
 	fstest.FS(t, options)

--- a/os/fs_test.go
+++ b/os/fs_test.go
@@ -127,6 +127,7 @@ func TestFSTest(t *testing.T) {
 	if runtime.GOOS == goosWindows {
 		constraints.FileModeMask = 0200
 		constraints.InvalidSeekWhenceUndefined = true
+		constraints.RenameToSelfNoOp = true
 	}
 
 	options := fstest.FSOptions{

--- a/os/fs_test.go
+++ b/os/fs_test.go
@@ -149,9 +149,10 @@ func TestFSTest(t *testing.T) {
 	if runtime.GOOS == goosWindows {
 		options.Constraints.FileModeMask = 0200
 		skipNames := map[string]struct{}{
-			"TestFSTest/osfs.FS#01/file.Seek/seek_unknown_start": {}, // Windows ignores invalid 'whence' values in Seek() calls.
-			"TestFSTest/osfs.FS/fs.Rename/same_directory":        {}, // Windows does not return an error for renaming a directory to itself.
-			"TestFSTest/osfs.FS/fs.Rename/newpath_is_directory":  {}, // Windows returns an access denied error when renaming a file to an existing directory.
+			"TestFSTest/osfs.FS#01/file.Seek/seek_unknown_start":                {}, // Windows ignores invalid 'whence' values in Seek() calls.
+			"TestFSTest/osfs.FS/fs.Rename/same_directory":                       {}, // Windows does not return an error for renaming a directory to itself.
+			"TestFSTest/osfs.FS/fs.Rename/newpath_is_directory":                 {}, // Windows returns an access denied error when renaming a file to an existing directory.
+			"TestFSTest/osfs.FS/fs.Chmod/change_symlink_target_permission_bits": {}, // Windows requires elevated permissions to create symlinks (sometimes).
 		}
 		options.ShouldSkip = func(facets fstest.Facets) bool {
 			_, skip := skipNames[facets.Name]

--- a/os/fs_test.go
+++ b/os/fs_test.go
@@ -149,10 +149,10 @@ func TestFSTest(t *testing.T) {
 	if runtime.GOOS == goosWindows {
 		options.Constraints.FileModeMask = 0200 // Windows does not support the typical file permission bits. Only the "owner writable" bit is supported.
 		skipNames := map[string]struct{}{
-			"TestFSTest/osfs.FS#01/file.Seek/seek_unknown_start":                {}, // Windows ignores invalid 'whence' values in Seek() calls.
-			"TestFSTest/osfs.FS/fs.Rename/same_directory":                       {}, // Windows does not return an error for renaming a directory to itself.
-			"TestFSTest/osfs.FS/fs.Rename/newpath_is_directory":                 {}, // Windows returns an access denied error when renaming a file to an existing directory.
-			"TestFSTest/osfs.FS/fs.Chmod/change_symlink_target_permission_bits": {}, // Windows requires elevated permissions to create symlinks (sometimes).
+			"TestFSTest/osfs.FS_File/file.Seek/seek_unknown_start":                 {}, // Windows ignores invalid 'whence' values in Seek() calls.
+			"TestFSTest/osfs.FS_FS/fs.Rename/same_directory":                       {}, // Windows does not return an error for renaming a directory to itself.
+			"TestFSTest/osfs.FS_FS/fs.Rename/newpath_is_directory":                 {}, // Windows returns an access denied error when renaming a file to an existing directory.
+			"TestFSTest/osfs.FS_FS/fs.Chmod/change_symlink_target_permission_bits": {}, // Windows requires elevated permissions to create symlinks (sometimes).
 		}
 		options.ShouldSkip = func(facets fstest.Facets) bool {
 			_, skip := skipNames[facets.Name]

--- a/os/fs_test.go
+++ b/os/fs_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestRootedPathGOOS(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		description string
 		root        string

--- a/os/fs_test.go
+++ b/os/fs_test.go
@@ -147,7 +147,7 @@ func TestFSTest(t *testing.T) {
 		},
 	}
 	if runtime.GOOS == goosWindows {
-		options.Constraints.FileModeMask = 0200
+		options.Constraints.FileModeMask = 0200 // Windows does not support the typical file permission bits. Only the "owner writable" bit is supported.
 		skipNames := map[string]struct{}{
 			"TestFSTest/osfs.FS#01/file.Seek/seek_unknown_start":                {}, // Windows ignores invalid 'whence' values in Seek() calls.
 			"TestFSTest/osfs.FS/fs.Rename/same_directory":                       {}, // Windows does not return an error for renaming a directory to itself.

--- a/os/fs_test.go
+++ b/os/fs_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/hack-pad/hackpadfs/internal/assert"
 )
 
+const (
+	goosLinux = "linux"
+)
+
 func TestRootedPathGOOS(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {

--- a/os/fs_test.go
+++ b/os/fs_test.go
@@ -5,6 +5,7 @@ package os
 
 import (
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -122,6 +123,11 @@ func TestFSTest(t *testing.T) {
 		setUmask(oldmask)
 	})
 
+	var constraints fstest.Constraints
+	if runtime.GOOS == goosWindows {
+		constraints.FileModeMask = 0200
+	}
+
 	options := fstest.FSOptions{
 		Name: "osfs.FS",
 		TestFS: func(tb testing.TB) fstest.SetupFS {
@@ -144,6 +150,7 @@ func TestFSTest(t *testing.T) {
 			}
 			return subFS.(*FS)
 		},
+		Constraints: constraints,
 	}
 	fstest.FS(t, options)
 	fstest.File(t, options)


### PR DESCRIPTION
Adds Windows support to os.FS, including automated regression tests.

Caveat: Some specific fstest tests are disabled to accommodate the slight platform differences.