### PR TITLE
idb: Fix inconsistently stored blob type

### DIFF
--- a/indexeddb/idbblob/blob.go
+++ b/indexeddb/idbblob/blob.go
@@ -86,7 +86,7 @@ func (b *Blob) Bytes() []byte {
 	jsBuf := b.jsValue.Load().(js.Value)
 	buf := make([]byte, jsBuf.Length())
 	js.CopyBytesToGo(buf, jsBuf)
-	b.bytes.Store(buf)
+	b.bytes.Store(blob.NewBytes(buf))
 	return buf
 }
 


### PR DESCRIPTION
This atomic value was incorrectly set to a byte slice instead of a `*blob.Bytes` type.