### PR TITLE
fix: js.Wrapper was removed in go1.19

### DIFF
--- a/indexeddb/idbblob/blob.go
+++ b/indexeddb/idbblob/blob.go
@@ -59,9 +59,15 @@ func newBlob(buf js.Value) *Blob {
 	return b
 }
 
+// JSWrapper is implemented by types that are backed by a JavaScript value.
+type JSWrapper interface {
+	// JSValue returns a JavaScript value associated with an object.
+	JSValue() js.Value
+}
+
 // FromBlob creates a Blob from the given blob.Blob, either wrapping the JS value or copying the bytes if incompatible.
 func FromBlob(b blob.Blob) *Blob {
-	if b, ok := b.(js.Wrapper); ok {
+	if b, ok := b.(JSWrapper); ok {
 		return newBlob(b.JSValue())
 	}
 	buf := b.Bytes()
@@ -90,7 +96,7 @@ func (b *Blob) Bytes() []byte {
 	return buf
 }
 
-// JSValue implements js.Wrapper
+// JSValue implements JSWrapper
 func (b *Blob) JSValue() js.Value {
 	return b.jsValue.Load().(js.Value)
 }

--- a/indexeddb/idbblob/blob.go
+++ b/indexeddb/idbblob/blob.go
@@ -59,15 +59,15 @@ func newBlob(buf js.Value) *Blob {
 	return b
 }
 
-// JSWrapper is implemented by types that are backed by a JavaScript value.
-type JSWrapper interface {
+// jsWrapper is implemented by types that are backed by a JavaScript value.
+type jsWrapper interface {
 	// JSValue returns a JavaScript value associated with an object.
 	JSValue() js.Value
 }
 
 // FromBlob creates a Blob from the given blob.Blob, either wrapping the JS value or copying the bytes if incompatible.
 func FromBlob(b blob.Blob) *Blob {
-	if b, ok := b.(JSWrapper); ok {
+	if b, ok := b.(jsWrapper); ok {
 		return newBlob(b.JSValue())
 	}
 	buf := b.Bytes()


### PR DESCRIPTION
Fixes build against go1.19

js.Wrapper was removed: add it back as JSWrapper.

https://github.com/golang/go/issues/50310

https://github.com/golang/go/commit/6c0daa733192031eab23d09ed6515c4cd959aa92#diff-38b359833111770b96ea3bb8bc5e2b807e18bdbb80684a397ce63ff05e6d02ecL31