### PR TITLE
Fix implementations of `*.FS.ReadDir()` when reading regular files

### DIFF
--- a/fstest/file.go
+++ b/fstest/file.go
@@ -661,8 +661,9 @@ func TestFileReadDir(tb testing.TB, o FSOptions) {
 			err := err.(*hackpadfs.PathError)
 			assert.ErrorIs(tb, hackpadfs.ErrNotDir, err)
 			assert.Contains(tb, []string{
-				"fdopendir",
-				"readdirent",
+				"fdopendir",  // macOS
+				"readdirent", // Linux
+				"readdir",    // Windows
 			}, err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}

--- a/fstest/file.go
+++ b/fstest/file.go
@@ -660,7 +660,10 @@ func TestFileReadDir(tb testing.TB, o FSOptions) {
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
 			assert.ErrorIs(tb, hackpadfs.ErrNotDir, err)
-			assert.Equal(tb, "fdopendir", err.Op)
+			assert.Contains(tb, []string{
+				"fdopendir",
+				"readdirent",
+			}, err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}
 		assert.Equal(tb, 0, len(entries))

--- a/fstest/fs.go
+++ b/fstest/fs.go
@@ -1148,7 +1148,7 @@ func TestReadDir(tb testing.TB, o FSOptions) {
 
 	o.tbRun(tb, "exists", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
-		err := hackpadfs.MkdirAll(setupFS, "foo/bar", 0700)
+		err := hackpadfs.MkdirAll(setupFS, "foo/bar", 0777)
 		assert.NoError(tb, err)
 		f, err := hackpadfs.Create(setupFS, "foo/baz")
 		if assert.NoError(tb, err) {
@@ -1170,7 +1170,7 @@ func TestReadDir(tb testing.TB, o FSOptions) {
 			assert.NoError(tb, err)
 			assert.Equal(tb, quickInfo{
 				Name:  "bar",
-				Mode:  hackpadfs.ModeDir | 0700,
+				Mode:  hackpadfs.ModeDir | 0777,
 				IsDir: true,
 			}, asQuickInfo(info))
 			assert.Equal(tb, true, dir[0].IsDir())

--- a/fstest/fs.go
+++ b/fstest/fs.go
@@ -1226,7 +1226,10 @@ func TestReadDir(tb testing.TB, o FSOptions) {
 		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
 			err := err.(*hackpadfs.PathError)
 			assert.ErrorIs(tb, hackpadfs.ErrNotDir, err)
-			assert.Equal(tb, "fdopendir", err.Op)
+			assert.Contains(tb, []string{
+				"fdopendir",
+				"readdirent",
+			}, err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}
 	})

--- a/fstest/fs.go
+++ b/fstest/fs.go
@@ -1227,8 +1227,9 @@ func TestReadDir(tb testing.TB, o FSOptions) {
 			err := err.(*hackpadfs.PathError)
 			assert.ErrorIs(tb, hackpadfs.ErrNotDir, err)
 			assert.Contains(tb, []string{
-				"fdopendir",
-				"readdirent",
+				"fdopendir",  // macOS
+				"readdirent", // Linux
+				"readdir",    // Windows
 			}, err.Op)
 			assert.Equal(tb, "foo", err.Path)
 		}

--- a/fstest/fs.go
+++ b/fstest/fs.go
@@ -1216,7 +1216,6 @@ func TestReadDir(tb testing.TB, o FSOptions) {
 
 	o.tbRun(tb, "file is not a dir", func(tb testing.TB) {
 		setupFS, commit := o.Setup.FS(tb)
-		const contents = "hello"
 		f, err := hackpadfs.Create(setupFS, "foo")
 		if assert.NoError(tb, err) {
 			assert.NoError(tb, f.Close())

--- a/fstest/fs.go
+++ b/fstest/fs.go
@@ -1137,4 +1137,100 @@ func TestReadFile(tb testing.TB, o FSOptions) {
 	})
 }
 
+func TestReadDir(tb testing.TB, o FSOptions) {
+	readDirFS := func(tb testing.TB, fs hackpadfs.FS) hackpadfs.ReadDirFS {
+		if fs, ok := fs.(hackpadfs.ReadDirFS); ok {
+			return fs
+		}
+		tb.Skip("FS is not a ReadDirFS")
+		return nil
+	}
+
+	o.tbRun(tb, "exists", func(tb testing.TB) {
+		setupFS, commit := o.Setup.FS(tb)
+		err := hackpadfs.MkdirAll(setupFS, "foo/bar", 0700)
+		assert.NoError(tb, err)
+		f, err := hackpadfs.Create(setupFS, "foo/baz")
+		if assert.NoError(tb, err) {
+			assert.NoError(tb, f.Close())
+		}
+		f, err = hackpadfs.Create(setupFS, "foo/biff")
+		if assert.NoError(tb, err) {
+			assert.NoError(tb, f.Close())
+		}
+		fs := readDirFS(tb, commit())
+		dir, err := fs.ReadDir("foo")
+		assert.NoError(tb, err)
+		if assert.Equal(tb, 3, len(dir)) {
+			// entries should be sorted alphabetically
+
+			// dir entry 0
+			assert.Equal(tb, "bar", dir[0].Name())
+			info, err := dir[0].Info()
+			assert.NoError(tb, err)
+			assert.Equal(tb, quickInfo{
+				Name:  "bar",
+				Mode:  hackpadfs.ModeDir | 0700,
+				IsDir: true,
+			}, asQuickInfo(info))
+			assert.Equal(tb, true, dir[0].IsDir())
+			assert.Equal(tb, hackpadfs.ModeDir, dir[0].Type())
+
+			// dir entry 1
+			assert.Equal(tb, "baz", dir[1].Name())
+			info, err = dir[1].Info()
+			assert.NoError(tb, err)
+			assert.Equal(tb, quickInfo{
+				Name:  "baz",
+				Mode:  0666,
+				IsDir: false,
+			}, asQuickInfo(info))
+			assert.Equal(tb, false, dir[1].IsDir())
+			assert.Equal(tb, hackpadfs.FileMode(0), dir[1].Type())
+
+			// dir entry 2
+			assert.Equal(tb, "biff", dir[2].Name())
+			info, err = dir[2].Info()
+			assert.NoError(tb, err)
+			assert.Equal(tb, quickInfo{
+				Name:  "biff",
+				Mode:  0666,
+				IsDir: false,
+			}, asQuickInfo(info))
+			assert.Equal(tb, false, dir[2].IsDir())
+			assert.Equal(tb, hackpadfs.FileMode(0), dir[2].Type())
+		}
+	})
+
+	o.tbRun(tb, "not exists", func(tb testing.TB) {
+		_, commit := o.Setup.FS(tb)
+		fs := readDirFS(tb, commit())
+		_, err := fs.ReadDir("foo")
+		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
+			err := err.(*hackpadfs.PathError)
+			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
+			assert.Equal(tb, "open", err.Op)
+			assert.Equal(tb, "foo", err.Path)
+		}
+	})
+
+	o.tbRun(tb, "file is not a dir", func(tb testing.TB) {
+		setupFS, commit := o.Setup.FS(tb)
+		const contents = "hello"
+		f, err := hackpadfs.Create(setupFS, "foo")
+		if assert.NoError(tb, err) {
+			assert.NoError(tb, f.Close())
+		}
+
+		fs := readDirFS(tb, commit())
+		_, err = fs.ReadDir("foo")
+		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
+			err := err.(*hackpadfs.PathError)
+			assert.ErrorIs(tb, hackpadfs.ErrNotDir, err)
+			assert.Equal(tb, "fdopendir", err.Op)
+			assert.Equal(tb, "foo", err.Path)
+		}
+	})
+}
+
 // TODO Symlink

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -195,6 +195,7 @@ func runFS(tb testing.TB, options FSOptions) {
 	runner.Run("fs.MkdirAll", TestMkdirAll)
 	runner.Run("fs.Open", TestOpen)
 	runner.Run("fs.OpenFile", TestOpenFile)
+	runner.Run("fs.ReadDir", TestReadDir)
 	runner.Run("fs.ReadFile", TestReadFile)
 	runner.Run("fs.Remove", TestRemove)
 	runner.Run("fs.RemoveAll", TestRemoveAll)

--- a/keyvalue/file.go
+++ b/keyvalue/file.go
@@ -334,7 +334,7 @@ func (f *file) Truncate(size int64) error {
 func (f *file) ReadDir(n int) ([]hackpadfs.DirEntry, error) {
 	dirNames, err := f.ReadDirNames()
 	if err != nil {
-		return nil, err
+		return nil, &hackpadfs.PathError{Op: "fdopendir", Path: f.path, Err: err}
 	}
 	start, end := f.offset, f.offset+int64(n)
 	if n <= 0 {

--- a/keyvalue/file.go
+++ b/keyvalue/file.go
@@ -334,7 +334,7 @@ func (f *file) Truncate(size int64) error {
 func (f *file) ReadDir(n int) ([]hackpadfs.DirEntry, error) {
 	dirNames, err := f.ReadDirNames()
 	if err != nil {
-		return nil, &hackpadfs.PathError{Op: "fdopendir", Path: f.path, Err: err}
+		return nil, &hackpadfs.PathError{Op: "readdir", Path: f.path, Err: err}
 	}
 	start, end := f.offset, f.offset+int64(n)
 	if n <= 0 {

--- a/mem/store.go
+++ b/mem/store.go
@@ -40,6 +40,9 @@ func (f fileRecord) ModTime() time.Time       { return f.modTime }
 func (f fileRecord) Sys() interface{}         { return nil }
 
 func (f fileRecord) ReadDirNames() ([]string, error) {
+	if !f.mode.IsDir() {
+		return nil, hackpadfs.ErrNotDir
+	}
 	var names []string
 	prefix := f.path + "/"
 	isRoot := f.path == "."


### PR DESCRIPTION

* Add ReadDir tests for reading a file as a directory
* Fix mem.FS.ReadDir() not returning ErrNotDir on a file
* Fix keyvalue path error type
