### PR TITLE
Update to Go 1.19, test on more versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.16.x
+        go-version: 1.19.x
     - name: Lint
       run: make lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: 1.16.x
     - name: Lint
       run: make lint
 
@@ -22,19 +22,19 @@ jobs:
         platform: 
         - ubuntu-latest
         go:
-        - 1.16
-        - 1.17
-        - 1.18
-        - 1.19
+        - 1.16.x
+        - 1.17.x
+        - 1.18.x
+        - 1.19.x
         include:
         - platform: macos-latest
-          go: 1.19
+          go: 1.19.x
         - platform: windows-latest
-          go: 1.19
+          go: 1.19.x
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
     - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,24 @@ jobs:
       matrix:
         platform: 
         - ubuntu-latest
-        - macos-latest
-        - windows-latest
+        go:
+        - 1.16
+        - 1.17
+        - 1.18
+        - 1.19
+        include:
+        - platform: macos-latest
+          go: 1.19
+        - platform: windows-latest
+          go: 1.19
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: ${{ matrix.go }}
     - name: Test
       run: make test
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERAGE_VERSION: 1.19

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test: test-deps
 		GOOS=js GOARCH=wasm go test -cover ./...; \
 		cd examples && go test -race ./...; \
 	fi
-	@if [[ "$$CI" == true && $$(uname -s) == Linux ]]; then \
+	@if [[ "$$CI" == true && $$(uname -s) == Linux && "$$(go version)" == *go"$$COVERAGE_VERSION"* ]]; then \
 		set -ex; \
 		goveralls -coverprofile=cover.out -service=github || true; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BROWSERTEST_VERSION = v0.3.5
-LINT_VERSION = 1.42.1
+LINT_VERSION = 1.50.1
 GO_BIN = $(shell printf '%s/bin' "$$(go env GOPATH)")
 SHELL = bash
 

--- a/cache/fs.go
+++ b/cache/fs.go
@@ -1,3 +1,4 @@
+// Package cache contains a read-only cache file system.
 package cache
 
 import (

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -939,6 +939,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hack-pad/go-indexeddb v0.1.0 h1:UzRAl6WiKxLJePkgi2uaQa9MMPWcjO29zI3pt9D+rNs=
 github.com/hack-pad/go-indexeddb v0.1.0/go.mod h1:NH8CaojufPNcKYDhy5JkjfyBXE/72oJPeiywlabN/lM=
+github.com/hack-pad/go-indexeddb v0.2.0 h1:QHDM6gLrtCJvHdHUK8UdibJu4xWQlIDs4+l8L65AUdA=
+github.com/hack-pad/go-indexeddb v0.2.0/go.mod h1:NH8CaojufPNcKYDhy5JkjfyBXE/72oJPeiywlabN/lM=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.3.0 h1:HXNYlRkkM/t+Y/Yhxtwcy02dlYwIaoxzvxPnS+cqy78=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=

--- a/examples/s3/fs.go
+++ b/examples/s3/fs.go
@@ -1,3 +1,4 @@
+// Package s3 contains an example S3 file system.
 package s3
 
 import (

--- a/examples/s3/fs_test.go
+++ b/examples/s3/fs_test.go
@@ -3,7 +3,6 @@ package s3
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -27,7 +26,7 @@ const (
 var minioClient *minio.Client
 
 func init() {
-	path, err := ioutil.TempDir("", "")
+	path, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}

--- a/fs.go
+++ b/fs.go
@@ -1,3 +1,4 @@
+// Package hackpadfs defines many essential file and file system interfaces as well as helpers for use with the standard library's 'io/fs' package.
 package hackpadfs
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/hack-pad/hackpadfs
 
 go 1.16
 
-require github.com/hack-pad/go-indexeddb v0.1.0
+require github.com/hack-pad/go-indexeddb v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/hack-pad/go-indexeddb v0.1.0 h1:UzRAl6WiKxLJePkgi2uaQa9MMPWcjO29zI3pt9D+rNs=
 github.com/hack-pad/go-indexeddb v0.1.0/go.mod h1:NH8CaojufPNcKYDhy5JkjfyBXE/72oJPeiywlabN/lM=
+github.com/hack-pad/go-indexeddb v0.2.0 h1:QHDM6gLrtCJvHdHUK8UdibJu4xWQlIDs4+l8L65AUdA=
+github.com/hack-pad/go-indexeddb v0.2.0/go.mod h1:NH8CaojufPNcKYDhy5JkjfyBXE/72oJPeiywlabN/lM=

--- a/indexeddb/fs.go
+++ b/indexeddb/fs.go
@@ -1,6 +1,7 @@
 //go:build wasm
 // +build wasm
 
+// Package indexeddb contains a WebAssembly compatible file system. Uses IndexedDB under the hood.
 package indexeddb
 
 import (

--- a/indexeddb/idbblob/blob.go
+++ b/indexeddb/idbblob/blob.go
@@ -1,6 +1,7 @@
 //go:build wasm
 // +build wasm
 
+// Package idbblob contains a JavaScript implementation of blob.Blob.
 package idbblob
 
 import (

--- a/indexeddb/idbblob/blob.go
+++ b/indexeddb/idbblob/blob.go
@@ -10,6 +10,7 @@ import (
 	"syscall/js"
 
 	"github.com/hack-pad/hackpadfs/internal/exception"
+	"github.com/hack-pad/hackpadfs/internal/jswrapper"
 	"github.com/hack-pad/hackpadfs/keyvalue/blob"
 )
 
@@ -59,15 +60,9 @@ func newBlob(buf js.Value) *Blob {
 	return b
 }
 
-// jsWrapper is implemented by types that are backed by a JavaScript value.
-type jsWrapper interface {
-	// JSValue returns a JavaScript value associated with an object.
-	JSValue() js.Value
-}
-
 // FromBlob creates a Blob from the given blob.Blob, either wrapping the JS value or copying the bytes if incompatible.
 func FromBlob(b blob.Blob) *Blob {
-	if b, ok := b.(jsWrapper); ok {
+	if b, ok := b.(jswrapper.Wrapper); ok {
 		return newBlob(b.JSValue())
 	}
 	buf := b.Bytes()
@@ -96,7 +91,7 @@ func (b *Blob) Bytes() []byte {
 	return buf
 }
 
-// JSValue implements JSWrapper
+// JSValue implements jswrapper.Wrapper
 func (b *Blob) JSValue() js.Value {
 	return b.jsValue.Load().(js.Value)
 }

--- a/indexeddb/idbblob/blob.go
+++ b/indexeddb/idbblob/blob.go
@@ -165,7 +165,7 @@ func (b *Blob) Set(src blob.Blob, destStart int64) (n int, err error) {
 	}
 
 	err = catchErr(func() error {
-		b.JSValue().Call("set", FromBlob(src), destStart)
+		b.JSValue().Call("set", FromBlob(src).JSValue(), destStart)
 		return nil
 	})
 	if err != nil {

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -1,3 +1,4 @@
+// Package assert contains common assertions on builtin types.
 package assert
 
 import (

--- a/internal/exception/exception.go
+++ b/internal/exception/exception.go
@@ -1,6 +1,7 @@
 //go:build wasm
 // +build wasm
 
+// Package exception contains exception handlers to make JavaScript interop easier.
 package exception
 
 import (

--- a/internal/exception/exception_test.go
+++ b/internal/exception/exception_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hack-pad/hackpadfs/internal/assert"
+	"github.com/hack-pad/hackpadfs/internal/jswrapper"
 )
 
 func TestCatch(t *testing.T) {
@@ -69,7 +70,7 @@ func TestCatch(t *testing.T) {
 func testJSErrValue() (value js.Value) {
 	defer func() {
 		recoverVal := recover()
-		value = recoverVal.(js.Wrapper).JSValue()
+		value = recoverVal.(jswrapper.Wrapper).JSValue()
 	}()
 	js.Global().Get("Function").New(`throw Exception("some error")`).Invoke()
 	panic("not a JS value. line above should do the panic")

--- a/internal/exception/exception_test.go
+++ b/internal/exception/exception_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/hack-pad/hackpadfs/internal/assert"
-	"github.com/hack-pad/hackpadfs/internal/jswrapper"
 )
 
 func TestCatch(t *testing.T) {
@@ -70,9 +69,9 @@ func TestCatch(t *testing.T) {
 func testJSErrValue() (value js.Value) {
 	defer func() {
 		recoverVal := recover()
-		value = recoverVal.(jswrapper.Wrapper).JSValue()
+		value = recoverVal.(js.Error).Value
 	}()
-	js.Global().Get("Function").New(`throw Exception("some error")`).Invoke()
+	js.Global().Get("Function").New(`throw new Error("some error")`).Invoke()
 	panic("not a JS value. line above should do the panic")
 }
 

--- a/internal/fserrors/errors.go
+++ b/internal/fserrors/errors.go
@@ -1,3 +1,4 @@
+// Package fserrors contains error wrappers.
 package fserrors
 
 type messageError struct {

--- a/internal/jswrapper/wrapper.go
+++ b/internal/jswrapper/wrapper.go
@@ -1,0 +1,12 @@
+//go:build wasm
+// +build wasm
+
+package jswrapper
+
+import "syscall/js"
+
+// Wrapper is implemented by types that are backed by a JavaScript value.
+type Wrapper interface {
+	// JSValue returns a JavaScript value associated with an object.
+	JSValue() js.Value
+}

--- a/internal/jswrapper/wrapper.go
+++ b/internal/jswrapper/wrapper.go
@@ -1,11 +1,13 @@
 //go:build wasm
 // +build wasm
 
+// Package jswrapper contains a Wrapper for interoperating with JavaScript.
 package jswrapper
 
 import "syscall/js"
 
 // Wrapper is implemented by types that are backed by a JavaScript value.
+// This wrapper was previously included in the standard library.
 type Wrapper interface {
 	// JSValue returns a JavaScript value associated with an object.
 	JSValue() js.Value

--- a/internal/mounttest/mounttest.go
+++ b/internal/mounttest/mounttest.go
@@ -1,3 +1,4 @@
+// Package mounttest contains mount.FS wrappers for more thorough testing.
 package mounttest
 
 import (

--- a/internal/pathlock/lock.go
+++ b/internal/pathlock/lock.go
@@ -1,3 +1,4 @@
+// Package pathlock contains Mutex, which locks and unlocks using file paths as keys.
 package pathlock
 
 import "sync"

--- a/keyvalue/blob/blob.go
+++ b/keyvalue/blob/blob.go
@@ -1,3 +1,4 @@
+// Package blob defines a common data interchange type for keyvalue FS's.
 package blob
 
 // Blob is a binary blob of data that can support platform-optimized mutations for better performance.

--- a/keyvalue/fs.go
+++ b/keyvalue/fs.go
@@ -1,3 +1,4 @@
+// Package keyvalue contains a key-value based FS for easy, custom FS implementations.
 package keyvalue
 
 import (

--- a/mem/fs.go
+++ b/mem/fs.go
@@ -1,3 +1,4 @@
+// Package mem contains an in-memory FS.
 package mem
 
 import (

--- a/mount/fs.go
+++ b/mount/fs.go
@@ -1,3 +1,4 @@
+// Package mount contains an implementation of hackpadfs.MountFS.
 package mount
 
 import (

--- a/os/fs.go
+++ b/os/fs.go
@@ -1,3 +1,4 @@
+// Package os implements all of the familiar behavior from the standard library using hackpadfs's interfaces.
 package os
 
 import (

--- a/os/path.go
+++ b/os/path.go
@@ -63,9 +63,9 @@ func (fs *FS) getVolumeName(goos string) string {
 // FromOSPath converts an absolute 'os' package path to the valid equivalent 'io/fs' package path for this FS.
 //
 // Returns an error for any of the following conditions:
-//   * The path is not absolute.
-//   * The path does not match fs's volume name set by SubVolume().
-//   * The path does not share fs's root path set by Sub().
+//   - The path is not absolute.
+//   - The path does not match fs's volume name set by SubVolume().
+//   - The path does not share fs's root path set by Sub().
 func (fs *FS) FromOSPath(osPath string) (string, error) {
 	if !filepath.IsAbs(osPath) {
 		return "", &hackpadfs.PathError{Op: osPathOp, Path: osPath, Err: hackpadfs.ErrInvalid}

--- a/tar/fs.go
+++ b/tar/fs.go
@@ -1,3 +1,4 @@
+// Package tar contains a tar file based file system.
 package tar
 
 import (


### PR DESCRIPTION
- Lint on Go 1.19.
- Test on more versions of Go: 1.16 through 1.19.
- Fix incompatibilities from Go 1.18 onward, particularly around `js.ValueOf()` and `js.Wrapper`.