### PR TITLE
Add `hackpadfs.WriteFullFile()` to call an optimized `fs.WriteFile()`

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -365,8 +365,11 @@ func WriteFullFile(fs FS, name string, data []byte, perm FileMode) error {
 
 	f, err := OpenFile(fs, name, FlagWriteOnly|FlagCreate|FlagTruncate, perm)
 	if err == nil {
-		defer f.Close()
 		_, err = WriteFile(f, data)
+		closeErr := f.Close()
+		if err == nil {
+			err = closeErr
+		}
 	}
 	return err
 }

--- a/fs_test.go
+++ b/fs_test.go
@@ -107,3 +107,14 @@ func TestChmod(t *testing.T) {
 	err = hackpadfs.Chmod(fs, "foo", 0)
 	assert.NoError(t, err)
 }
+
+func TestWriteFullFile(t *testing.T) {
+	t.Parallel()
+
+	fs := makeSimplerFS(t)
+	err := hackpadfs.WriteFullFile(fs, "foo", []byte("bar"), 0756)
+	assert.NoError(t, err)
+	contents, err := hackpadfs.ReadFile(fs, "foo")
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", string(contents))
+}

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -190,6 +190,8 @@ func runFS(tb testing.TB, options FSOptions) {
 	runner.Run("base fs.Chmod", TestBaseChmod)
 	runner.Run("base fs.Chtimes", TestBaseChtimes)
 
+	runner.Run("fs.Chmod", TestChmod)
+	runner.Run("fs.Chtimes", TestChtimes)
 	runner.Run("fs.Create", TestCreate)
 	runner.Run("fs.Mkdir", TestMkdir)
 	runner.Run("fs.MkdirAll", TestMkdirAll)
@@ -201,8 +203,7 @@ func runFS(tb testing.TB, options FSOptions) {
 	runner.Run("fs.RemoveAll", TestRemoveAll)
 	runner.Run("fs.Rename", TestRename)
 	runner.Run("fs.Stat", TestStat)
-	runner.Run("fs.Chmod", TestChmod)
-	runner.Run("fs.Chtimes", TestChtimes)
+	runner.Run("fs.WriteFile", TestWriteFile)
 	// TODO Symlink
 
 	runner.Run("fs_concurrent.Create", TestConcurrentCreate)

--- a/os/fs.go
+++ b/os/fs.go
@@ -241,6 +241,16 @@ func (fs *FS) ReadFile(name string) ([]byte, error) {
 	return contents, fs.wrapErr(err)
 }
 
+// WriteFile implements hackpadfs.WriteFileFS
+func (fs *FS) WriteFile(name string, data []byte, perm hackpadfs.FileMode) error {
+	name, pathErr := fs.rootedPath("writefile", name)
+	if pathErr != nil {
+		return pathErr
+	}
+	err := os.WriteFile(name, data, perm)
+	return fs.wrapErr(err)
+}
+
 // Symlink implements hackpadfs.SymlinkFS
 func (fs *FS) Symlink(oldname, newname string) error {
 	oldname, pathErr := fs.rootedPath("symlink", oldname)


### PR DESCRIPTION

Add `hackpadfs.WriteFullFile()` to call an optimized `fs.WriteFile()`.
