### PR TITLE
Implement MountFS on `Sub()` fallback to support non-read operations

### DIFF
--- a/file.go
+++ b/file.go
@@ -113,6 +113,12 @@ type ChtimeserFile interface {
 	Chtimes(atime time.Time, mtime time.Time) error
 }
 
+// WrappedFile is a File that can unwrap to return the original file along with its sub path.
+type WrappedFile interface {
+	File
+	Unwrap() (file File, subPath string)
+}
+
 // ChmodFile runs file.Chmod() is available, fails with a not implemented error otherwise.
 func ChmodFile(file File, mode FileMode) error {
 	if file, ok := file.(ChmoderFile); ok {

--- a/file.go
+++ b/file.go
@@ -113,12 +113,6 @@ type ChtimeserFile interface {
 	Chtimes(atime time.Time, mtime time.Time) error
 }
 
-// WrappedFile is a File that can unwrap to return the original file along with its sub path.
-type WrappedFile interface {
-	File
-	Unwrap() (file File, subPath string)
-}
-
 // ChmodFile runs file.Chmod() is available, fails with a not implemented error otherwise.
 func ChmodFile(file File, mode FileMode) error {
 	if file, ok := file.(ChmoderFile); ok {

--- a/fstest/assert.go
+++ b/fstest/assert.go
@@ -96,3 +96,47 @@ func (o FSOptions) assertSubsetQuickInfos(tb testing.TB, a, b []quickInfo) bool 
 	}
 	return assert.Subset(tb, a, b)
 }
+
+func (o FSOptions) assertEqualPathErr(tb testing.TB, expected *hackpadfs.PathError, actual error) {
+	tb.Helper()
+	if !assert.IsType(tb, (*hackpadfs.PathError)(nil), actual) {
+		return
+	}
+	actualPathErr := actual.(*hackpadfs.PathError)
+	assert.Equal(tb, expected.Op, actualPathErr.Op)
+	o.assertEqualErrPath(tb, expected.Path, actualPathErr.Path)
+	o.assertEqualErrField(tb, expected.Err, actualPathErr.Err)
+}
+
+func (o FSOptions) assertEqualLinkErr(tb testing.TB, expected *hackpadfs.LinkError, actual error) {
+	tb.Helper()
+	if !assert.IsType(tb, (*hackpadfs.LinkError)(nil), actual) {
+		return
+	}
+	actualLinkErr := actual.(*hackpadfs.LinkError)
+	assert.Equal(tb, expected.Op, actualLinkErr.Op)
+	o.assertEqualErrPath(tb, expected.Old, actualLinkErr.Old)
+	o.assertEqualErrPath(tb, expected.New, actualLinkErr.New)
+	o.assertEqualErrField(tb, expected.Err, actualLinkErr.Err)
+}
+
+func (o FSOptions) assertEqualErrPath(tb testing.TB, expected, actual string) {
+	tb.Helper()
+	if o.Constraints.AllowErrPathPrefix && expected != actual {
+		assert.Suffix(tb, "/"+expected, actual)
+	} else {
+		assert.Equal(tb, expected, actual)
+	}
+}
+
+func (o FSOptions) assertEqualErrField(tb testing.TB, expected, actual error) {
+	tb.Helper()
+	if !assert.NotZero(tb, expected) || !assert.NotZero(tb, actual) {
+		return
+	}
+	errorIs := errors.Is(actual, expected)
+	equalErr := expected.Error() == actual.Error()
+	if !errorIs && !equalErr {
+		assert.ErrorIs(tb, expected, actual)
+	}
+}

--- a/fstest/fs.go
+++ b/fstest/fs.go
@@ -155,24 +155,22 @@ func testCreate(tb testing.TB, o FSOptions, createFn func(hackpadfs.FS, string) 
 		assert.NoError(tb, setupFS.Mkdir("foo", 0700))
 		fs := commit()
 		_, err := createFn(fs, "foo")
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.Equal(tb, "open", err.Op)
-			assert.Equal(tb, "foo", err.Path)
-			assert.ErrorIs(tb, hackpadfs.ErrIsDir, err)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "open",
+			Path: "foo",
+			Err:  hackpadfs.ErrIsDir,
+		}, err)
 	})
 
 	o.tbRun(tb, "parent directory must exist", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := commit()
 		_, err := createFn(fs, "foo/bar")
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.Equal(tb, "open", err.Op)
-			assert.Equal(tb, "foo/bar", err.Path)
-			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "open",
+			Path: "foo/bar",
+			Err:  hackpadfs.ErrNotExist,
+		}, err)
 	})
 }
 
@@ -215,12 +213,11 @@ func TestMkdir(tb testing.TB, o FSOptions) {
 		skipNotImplemented(tb, err)
 		assert.NoError(tb, err)
 		err = hackpadfs.Mkdir(fs, "foo", 0600)
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.ErrorIs(tb, hackpadfs.ErrExist, err)
-			assert.Equal(tb, "mkdir", err.Op)
-			assert.Equal(tb, "foo", err.Path)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "mkdir",
+			Path: "foo",
+			Err:  hackpadfs.ErrExist,
+		}, err)
 		o.tryAssertEqualFS(tb, map[string]fsEntry{
 			"foo": {Mode: hackpadfs.ModeDir | 0600, IsDir: true},
 		}, fs)
@@ -236,12 +233,11 @@ func TestMkdir(tb testing.TB, o FSOptions) {
 		fs := commit()
 		err = hackpadfs.Mkdir(fs, "foo", 0600)
 		skipNotImplemented(tb, err)
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.ErrorIs(tb, hackpadfs.ErrExist, err)
-			assert.Equal(tb, "mkdir", err.Op)
-			assert.Equal(tb, "foo", err.Path)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "mkdir",
+			Path: "foo",
+			Err:  hackpadfs.ErrExist,
+		}, err)
 		o.tryAssertEqualFS(tb, map[string]fsEntry{
 			"foo": {Mode: 0666},
 		}, fs)
@@ -279,12 +275,11 @@ func TestMkdir(tb testing.TB, o FSOptions) {
 		fs := commit()
 		err := hackpadfs.Mkdir(fs, "foo/bar", 0755)
 		skipNotImplemented(tb, err)
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
-			assert.Equal(tb, "mkdir", err.Op)
-			assert.Equal(tb, "foo/bar", err.Path)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "mkdir",
+			Path: "foo/bar",
+			Err:  hackpadfs.ErrNotExist,
+		}, err)
 		o.tryAssertEqualFS(tb, map[string]fsEntry{}, fs)
 	})
 }
@@ -341,12 +336,11 @@ func TestMkdirAll(tb testing.TB, o FSOptions) {
 		fs := commit()
 		err = hackpadfs.MkdirAll(fs, "foo/bar", 0700)
 		skipNotImplemented(tb, err)
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.ErrorIs(tb, hackpadfs.ErrNotDir, err)
-			assert.Equal(tb, "mkdir", err.Op)
-			assert.Equal(tb, "foo", err.Path)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "mkdir",
+			Path: "foo",
+			Err:  hackpadfs.ErrNotDir,
+		}, err)
 		o.tryAssertEqualFS(tb, map[string]fsEntry{
 			"foo": {Mode: 0666},
 		}, fs)
@@ -379,25 +373,22 @@ func testOpen(tb testing.TB, o FSOptions, openFn func(hackpadfs.FS, string) (hac
 		_, commit := o.Setup.FS(tb)
 		fs := commit()
 		_, err := openFn(fs, "foo/../bar")
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			tb.Log(err.Err)
-			assert.ErrorIs(tb, hackpadfs.ErrInvalid, err)
-			assert.Equal(tb, "open", err.Op)
-			assert.Equal(tb, "foo/../bar", err.Path)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "open",
+			Path: "foo/../bar",
+			Err:  hackpadfs.ErrInvalid,
+		}, err)
 	})
 
 	o.tbRun(tb, "does not exist", func(tb testing.TB) {
 		_, commit := o.Setup.FS(tb)
 		fs := commit()
 		_, err := openFn(fs, "foo")
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
-			assert.Equal(tb, "open", err.Op)
-			assert.Equal(tb, "foo", err.Path)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "open",
+			Path: "foo",
+			Err:  hackpadfs.ErrNotExist,
+		}, err)
 	})
 
 	o.tbRun(tb, "open file", func(tb testing.TB) {
@@ -517,12 +508,11 @@ func TestOpenFile(tb testing.TB, o FSOptions) {
 		fs := commit()
 		_, err := hackpadfs.OpenFile(fs, "foo", hackpadfs.FlagTruncate|hackpadfs.FlagWriteOnly, 0700)
 		skipNotImplemented(tb, err)
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
-			assert.Equal(tb, "open", err.Op)
-			assert.Equal(tb, "foo", err.Path)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "open",
+			Path: "foo",
+			Err:  hackpadfs.ErrNotExist,
+		}, err)
 	})
 
 	o.tbRun(tb, "truncate on existing dir", func(tb testing.TB) {
@@ -531,12 +521,11 @@ func TestOpenFile(tb testing.TB, o FSOptions) {
 		fs := commit()
 		_, err := hackpadfs.OpenFile(fs, "foo", hackpadfs.FlagTruncate|hackpadfs.FlagWriteOnly, 0700)
 		skipNotImplemented(tb, err)
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.ErrorIs(tb, hackpadfs.ErrIsDir, err)
-			assert.Equal(tb, "open", err.Op)
-			assert.Equal(tb, "foo", err.Path)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "open",
+			Path: "foo",
+			Err:  hackpadfs.ErrIsDir,
+		}, err)
 	})
 
 	o.tbRun(tb, "append flag writes to end", func(tb testing.TB) {
@@ -598,12 +587,11 @@ func TestRemove(tb testing.TB, o FSOptions) {
 		fs := commit()
 		err := hackpadfs.Remove(fs, "foo")
 		skipNotImplemented(tb, err)
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
-			assert.Equal(tb, "remove", err.Op)
-			assert.Equal(tb, "foo", err.Path)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "remove",
+			Path: "foo",
+			Err:  hackpadfs.ErrNotExist,
+		}, err)
 		o.tryAssertEqualFS(tb, map[string]fsEntry{}, fs)
 	})
 
@@ -618,12 +606,11 @@ func TestRemove(tb testing.TB, o FSOptions) {
 		fs := commit()
 		err = hackpadfs.Remove(fs, "foo")
 		skipNotImplemented(tb, err)
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.ErrorIs(tb, hackpadfs.ErrNotEmpty, err)
-			assert.Equal(tb, "remove", err.Op)
-			assert.Equal(tb, "foo", err.Path)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "remove",
+			Path: "foo",
+			Err:  hackpadfs.ErrNotEmpty,
+		}, err)
 		o.tryAssertEqualFS(tb, map[string]fsEntry{
 			"foo":     {Mode: hackpadfs.ModeDir | 0700, IsDir: true},
 			"foo/bar": {Mode: 0666},
@@ -698,13 +685,12 @@ func TestRename(tb testing.TB, o FSOptions) {
 		fs := commit()
 		err := hackpadfs.Rename(fs, "foo", "bar")
 		skipNotImplemented(tb, err)
-		if assert.IsType(tb, &hackpadfs.LinkError{}, err) {
-			err := err.(*hackpadfs.LinkError)
-			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
-			assert.Equal(tb, "rename", err.Op)
-			assert.Equal(tb, "foo", err.Old)
-			assert.Equal(tb, "bar", err.New)
-		}
+		o.assertEqualLinkErr(tb, &hackpadfs.LinkError{
+			Op:  "rename",
+			Old: "foo",
+			New: "bar",
+			Err: hackpadfs.ErrNotExist,
+		}, err)
 	})
 
 	o.tbRun(tb, "inside same directory", func(tb testing.TB) {
@@ -766,15 +752,18 @@ func TestRename(tb testing.TB, o FSOptions) {
 		skipNotImplemented(tb, err)
 
 		if assert.Error(tb, err) {
-			assert.ErrorIs(tb, hackpadfs.ErrExist, err)
 			switch err := err.(type) {
 			case *hackpadfs.LinkError:
-				assert.Equal(tb, "rename", err.Op)
-				assert.Equal(tb, "foo", err.Old)
-				assert.Equal(tb, "foo", err.New)
+				o.assertEqualLinkErr(tb, &hackpadfs.LinkError{
+					Op:  "rename",
+					Old: "foo",
+					New: "foo",
+					Err: hackpadfs.ErrExist,
+				}, err)
 			default:
 				assert.Equal(tb, "*os.LinkError", fmt.Sprintf("%T", err))
 				assert.Equal(tb, "rename foo foo: file exists", err.Error())
+				assert.ErrorIs(tb, hackpadfs.ErrExist, err)
 			}
 		}
 		o.tryAssertEqualFS(tb, map[string]fsEntry{
@@ -791,15 +780,18 @@ func TestRename(tb testing.TB, o FSOptions) {
 		err := hackpadfs.Rename(fs, "foo", "bar")
 		skipNotImplemented(tb, err)
 		if assert.Error(tb, err) {
-			assert.ErrorIs(tb, hackpadfs.ErrExist, err)
 			switch err := err.(type) {
 			case *hackpadfs.LinkError:
-				assert.Equal(tb, "rename", err.Op)
-				assert.Equal(tb, "foo", err.Old)
-				assert.Equal(tb, "bar", err.New)
+				o.assertEqualLinkErr(tb, &hackpadfs.LinkError{
+					Op:  "rename",
+					Old: "foo",
+					New: "bar",
+					Err: hackpadfs.ErrExist,
+				}, err)
 			default:
 				assert.Equal(tb, "*os.LinkError", fmt.Sprintf("%T", err))
 				assert.Equal(tb, "rename foo bar: file exists", err.Error())
+				assert.ErrorIs(tb, hackpadfs.ErrExist, err)
 			}
 		}
 		o.tryAssertEqualFS(tb, map[string]fsEntry{
@@ -1021,12 +1013,11 @@ func TestChtimes(tb testing.TB, o FSOptions) {
 		fs := commit()
 		err := hackpadfs.Chtimes(fs, "foo", accessTime, modifyTime)
 		skipNotImplemented(tb, err)
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
-			assert.Equal(tb, "chtimes", err.Op)
-			assert.Equal(tb, "foo", err.Path)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "chtimes",
+			Path: "foo",
+			Err:  hackpadfs.ErrNotExist,
+		}, err)
 	})
 
 	o.tbRun(tb, "change access and modify times", func(tb testing.TB) {
@@ -1057,12 +1048,11 @@ func TestReadFile(tb testing.TB, o FSOptions) {
 		fs := commit()
 		_, err := hackpadfs.ReadFile(fs, "foo")
 		skipNotImplemented(tb, err)
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
-			assert.Equal(tb, "open", err.Op)
-			assert.Equal(tb, "foo", err.Path)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "open",
+			Path: "foo",
+			Err:  hackpadfs.ErrNotExist,
+		}, err)
 	})
 
 	o.tbRun(tb, "exists", func(tb testing.TB) {
@@ -1142,12 +1132,11 @@ func TestReadDir(tb testing.TB, o FSOptions) {
 		fs := commit()
 		_, err := hackpadfs.ReadDir(fs, "foo")
 		skipNotImplemented(tb, err)
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.ErrorIs(tb, hackpadfs.ErrNotExist, err)
-			assert.Equal(tb, "open", err.Op)
-			assert.Equal(tb, "foo", err.Path)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "open",
+			Path: "foo",
+			Err:  hackpadfs.ErrNotExist,
+		}, err)
 	})
 
 	o.tbRun(tb, "file is not a dir", func(tb testing.TB) {
@@ -1168,7 +1157,7 @@ func TestReadDir(tb testing.TB, o FSOptions) {
 				"readdirent", // Linux
 				"readdir",    // Windows
 			}, err.Op)
-			assert.Equal(tb, "foo", err.Path)
+			o.assertEqualErrPath(tb, "foo", err.Path)
 		}
 	})
 }
@@ -1229,12 +1218,11 @@ func TestWriteFile(tb testing.TB, o FSOptions) {
 		fs := commit()
 		err = hackpadfs.WriteFullFile(fs, "foo", []byte("bar"), 0765)
 		skipNotImplemented(tb, err)
-		if assert.IsType(tb, &hackpadfs.PathError{}, err) {
-			err := err.(*hackpadfs.PathError)
-			assert.ErrorIs(tb, hackpadfs.ErrIsDir, err)
-			assert.Equal(tb, "open", err.Op)
-			assert.Equal(tb, "foo", err.Path)
-		}
+		o.assertEqualPathErr(tb, &hackpadfs.PathError{
+			Op:   "open",
+			Path: "foo",
+			Err:  hackpadfs.ErrIsDir,
+		}, err)
 
 		o.tryAssertEqualFS(tb, map[string]fsEntry{
 			"foo": {Mode: 0700, IsDir: true},

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -69,6 +69,8 @@ func (fn TestSetupFunc) FS(tb testing.TB) (SetupFS, func() hackpadfs.FS) {
 type Constraints struct {
 	// FileModeMask disables mode checks on the specified bits. Defaults to checking all bits (0).
 	FileModeMask hackpadfs.FileMode
+	// AllowErrPathPrefix enables more flexible FS path checks on error values by allowing an undefined path prefix.
+	AllowErrPathPrefix bool
 }
 
 // Facets contains details for the current test.

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -185,6 +185,16 @@ func Prefix(tb testing.TB, expected, actual string) bool {
 	return true
 }
 
+// Suffix asserts actual ends with expected
+func Suffix(tb testing.TB, expected, actual string) bool {
+	tb.Helper()
+	if !strings.HasSuffix(actual, expected) {
+		tb.Errorf("Actual is not suffixed with expected:\nExpected: %s\nActual:   %s", expected, actual)
+		return false
+	}
+	return true
+}
+
 // Subset asserts 'sub' is a subset of 'super'
 func Subset(tb testing.TB, sub, super interface{}) bool {
 	tb.Helper()

--- a/mount.go
+++ b/mount.go
@@ -1,0 +1,27 @@
+package hackpadfs
+
+import "strings"
+
+func stripErrPathPrefix(err error, name, mountSubPath string) error {
+	if err == nil {
+		return err
+	}
+	prefix := strings.TrimSuffix(mountSubPath, name)
+	switch err := err.(type) {
+	case *PathError:
+		return &PathError{
+			Op:   err.Op,
+			Path: strings.TrimPrefix(err.Path, prefix),
+			Err:  err.Err,
+		}
+	case *LinkError:
+		return &LinkError{
+			Op:  err.Op,
+			Old: strings.TrimPrefix(err.Old, prefix),
+			New: strings.TrimPrefix(err.New, prefix),
+			Err: err.Err,
+		}
+	default:
+		return err
+	}
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestStripErrPathPrefix(t *testing.T) {
+	t.Parallel()
 	someError := errors.New("some error")
 	for _, tc := range []struct {
 		err          error
@@ -69,7 +70,9 @@ func TestStripErrPathPrefix(t *testing.T) {
 			},
 		},
 	} {
+		tc := tc // enable parallel sub-tests
 		t.Run(fmt.Sprint(tc.err, tc.name, tc.mountSubPath), func(t *testing.T) {
+			t.Parallel()
 			err := stripErrPathPrefix(tc.err, tc.name, tc.mountSubPath)
 			assert.Equal(t, tc.expectErr, err)
 		})

--- a/mount_test.go
+++ b/mount_test.go
@@ -1,0 +1,77 @@
+package hackpadfs
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hack-pad/hackpadfs/internal/assert"
+)
+
+func TestStripErrPathPrefix(t *testing.T) {
+	someError := errors.New("some error")
+	for _, tc := range []struct {
+		err          error
+		name         string
+		mountSubPath string
+		expectErr    error
+	}{
+		{
+			err:       nil,
+			expectErr: nil,
+		},
+		{
+			err:       someError,
+			expectErr: someError,
+		},
+		{
+			err: &PathError{
+				Op:   "foo",
+				Path: "biff/baz/bar",
+				Err:  someError,
+			},
+			name:         "baz/bar",
+			mountSubPath: "biff/baz/bar",
+			expectErr: &PathError{
+				Op:   "foo",
+				Path: "baz/bar",
+				Err:  someError,
+			},
+		},
+		{
+			err: &PathError{
+				Op:   "foo",
+				Path: "biff/baz/bar",
+				Err:  someError,
+			},
+			name:         "biff/baz/bar",
+			mountSubPath: "biff/baz/bar",
+			expectErr: &PathError{
+				Op:   "foo",
+				Path: "biff/baz/bar",
+				Err:  someError,
+			},
+		},
+		{
+			err: &LinkError{
+				Op:  "foo",
+				Old: "biff/baz/bar",
+				New: "biff/baz/bat",
+				Err: someError,
+			},
+			name:         "baz/bar",
+			mountSubPath: "biff/baz/bar",
+			expectErr: &LinkError{
+				Op:  "foo",
+				Old: "baz/bar",
+				New: "baz/bat",
+				Err: someError,
+			},
+		},
+	} {
+		t.Run(fmt.Sprint(tc.err, tc.name, tc.mountSubPath), func(t *testing.T) {
+			err := stripErrPathPrefix(tc.err, tc.name, tc.mountSubPath)
+			assert.Equal(t, tc.expectErr, err)
+		})
+	}
+}

--- a/sub.go
+++ b/sub.go
@@ -1,0 +1,41 @@
+package hackpadfs
+
+import (
+	"path"
+)
+
+var _ interface {
+	FS
+	MountFS
+} = &subFS{}
+
+type subFS struct {
+	basePath string
+	rootFS   FS
+}
+
+func newSubFS(fs FS, dir string) (FS, error) {
+	if !ValidPath(dir) {
+		return nil, &PathError{Op: "sub", Path: dir, Err: ErrInvalid}
+	}
+	return &subFS{
+		basePath: dir,
+		rootFS:   fs,
+	}, nil
+}
+
+func (fs *subFS) Open(name string) (File, error) {
+	if !ValidPath(name) {
+		return nil, &PathError{Op: "open", Path: name, Err: ErrInvalid}
+	}
+	mount, subPath := fs.Mount(name)
+	file, err := mount.Open(subPath)
+	return file, stripErrPathPrefix(err, name, subPath)
+}
+
+func (fs *subFS) Mount(p string) (mount FS, subPath string) {
+	if !ValidPath(p) {
+		return fs.rootFS, p
+	}
+	return fs.rootFS, path.Join(fs.basePath, p)
+}

--- a/sub_test.go
+++ b/sub_test.go
@@ -1,0 +1,49 @@
+package hackpadfs_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/hack-pad/hackpadfs"
+	"github.com/hack-pad/hackpadfs/fstest"
+	"github.com/hack-pad/hackpadfs/internal/assert"
+	"github.com/hack-pad/hackpadfs/mem"
+)
+
+func TestSub(t *testing.T) {
+	t.Parallel()
+	options := fstest.FSOptions{
+		Name:  "sub",
+		Setup: fstest.TestSetupFunc(setupSubFS),
+	}
+	data := fstest.FS(t, options)
+	assert.Zero(t, data.Skips)
+
+	options.Constraints = fstest.Constraints{
+		AllowErrPathPrefix: true,
+	}
+	data = fstest.File(t, options)
+	assert.Zero(t, data.Skips)
+}
+
+func setupSubFS(tb testing.TB) (fstest.SetupFS, func() hackpadfs.FS) {
+	memRoot, err := mem.NewFS()
+	requireNoError(tb, err)
+	return memRoot, func() hackpadfs.FS {
+		const subDir = "subfs-subdir"
+		requireNoError(tb, memRoot.Mkdir(subDir, 0700))
+		dirEntries, err := hackpadfs.ReadDir(memRoot, ".")
+		requireNoError(tb, err)
+		for _, entry := range dirEntries {
+			if entry.Name() == subDir {
+				continue
+			}
+			err := memRoot.Rename(entry.Name(), path.Join(subDir, entry.Name()))
+			requireNoError(tb, err)
+		}
+
+		fs, err := hackpadfs.Sub(memRoot, subDir)
+		requireNoError(tb, err)
+		return fs
+	}
+}


### PR DESCRIPTION
Implements MountFS on `Sub()` fallback to support non-read operations.

Caveat: The `PathError`s returned from `File` operations use their original `Path` values.

This is a limitation of the current MountFS design, where the returned File from Open(), OpenFile(), and Create() are returned as-is to support direct interface checks in client code.

Wrappers would break this behavior and therefore were avoided.

Part of #21 