### PR TITLE
Return concrete *os.FS from Sub() and Subvolume()

### DIFF
--- a/os/fs.go
+++ b/os/fs.go
@@ -32,7 +32,7 @@ func NewFS() *FS {
 
 // SubVolume is like Sub, but only sets the volume name (i.e. for Windows).
 // Calling SubVolume again on the returned FS results in an error.
-func (fs *FS) SubVolume(volumeName string) (hackpadfs.FS, error) {
+func (fs *FS) SubVolume(volumeName string) (*FS, error) {
 	if fs.root != "" {
 		return nil, &hackpadfs.PathError{Op: "subvolume", Path: volumeName, Err: errors.New("subvolume not supported on a SubFS")}
 	}
@@ -48,7 +48,7 @@ func (fs *FS) SubVolume(volumeName string) (hackpadfs.FS, error) {
 }
 
 // Sub implements hackpadfs.SubFS
-func (fs *FS) Sub(dir string) (hackpadfs.FS, error) {
+func (fs *FS) Sub(dir string) (*FS, error) {
 	if !hackpadfs.ValidPath(dir) {
 		return nil, &hackpadfs.PathError{Op: "sub", Path: dir, Err: hackpadfs.ErrInvalid}
 	}

--- a/os/fs_test.go
+++ b/os/fs_test.go
@@ -31,7 +31,7 @@ func TestFSTest(t *testing.T) {
 				if !assert.NoError(tb, err) {
 					tb.FailNow()
 				}
-				fs = subvFS.(*FS)
+				fs = subvFS
 				dir = dir[len(volumeName)+1:]
 			} else {
 				dir = strings.TrimPrefix(dir, "/")
@@ -40,7 +40,7 @@ func TestFSTest(t *testing.T) {
 			if !assert.NoError(tb, err) {
 				tb.FailNow()
 			}
-			return subFS.(*FS)
+			return subFS
 		},
 	}
 	var skipFacets []fstest.Facets


### PR DESCRIPTION
_First of all thanks for sharing this great project!_

While switching between `mem.FS` and `os.FS` for different use cases, I noticed that the value returned by `(*os.FS).Sub()` could not be passed verbatim to receivers that accept an interface such as `hpfs.RemoveFS`. This is because both `Sub()` and `Subvolume()` return a generic `hpfs.FS` interface instead of the concrete `*os.FS` type.

It is a common practice in Go to "accept interfaces, return concrete types" and, since there is no ambiguity here, I believe that returning the concrete `*os.FS` is the right thing to do. It avoids awkward assertions such as:

```go
fs := os.NewFS()
fsi, err := fs.Sub(webroot)
if err != nil { /* ... */ }
fs = fsi.(*os.FS)

myfunc(fs)
```